### PR TITLE
Count g_fCurrentRunTime only if the player's timer is running

### DIFF
--- a/addons/sourcemod/scripting/surftimer/misc.sp
+++ b/addons/sourcemod/scripting/surftimer/misc.sp
@@ -1464,7 +1464,10 @@ public void GetcurrentRunTime(int client)
 	}
 	else // If not in PracMode then use normal CurrentRunTime
 	{
-		g_fCurrentRunTime[client] = fGetGameTime - g_fStartTime[client] - fPauseTime;
+		if (g_bTimerRunning[client])
+			g_fCurrentRunTime[client] = fGetGameTime - g_fStartTime[client] - fPauseTime;
+		else
+			g_fCurrentRunTime[client] = -1.0;
 	}
 	
 	if (g_bWrcpTimeractivated[client])


### PR DESCRIPTION
This commit changes the way `g_fCurrentRunTime` is counted, by limiting it to only count if the player's timer is actually running. It will also default `g_fCurrentRunTime` to `-1` if the timer is not running.

Before this commit, it would calculate `g_fCurrentRunTime` no matter what the status of the player's timer is. The problem with the previous system is that if `g_fStartTime[client]` is set to `-1`, which it will be if your timer is not running, `g_fCurrentRunTime` will be whatever GetGameTime is - this can lead to major issues with other parts of the timer, such as the replay system always aborting saving a replay if `g_fCurrentRunTime` is above 2 hours (which it always will be since `g_fStartTime` will always be -1 once you hit the end zone and the replay saving routine is called).

