### PR TITLE
Update convars.sp

### DIFF
--- a/addons/sourcemod/scripting/surftimer/convars.sp
+++ b/addons/sourcemod/scripting/surftimer/convars.sp
@@ -138,18 +138,18 @@ void CreateConVars()
 	g_hRadioCommands = AutoExecConfig_CreateConVar("ck_use_radio", "0", "on/off - Allows players to use radio commands", _, true, 0.0, true, 1.0);
 	g_hAutohealing_Hp = AutoExecConfig_CreateConVar("ck_autoheal", "50", "Sets HP amount for autohealing (requires ck_godmode 0)", _, true, 0.0, true, 100.0);
 	g_hDynamicTimelimit = AutoExecConfig_CreateConVar("ck_dynamic_timelimit", "0", "on/off - Sets a suitable timelimit by calculating the average run time (This method requires ck_map_end 1, greater than 5 map times and a default timelimit in your server config for maps with less than 5 times", _, true, 0.0, true, 1.0);
-	g_hWelcomeMsg = AutoExecConfig_CreateConVar("ck_welcome_msg", "{yellow}>>{default} {grey}Welcome! This server is using {lime}SurfTimer", "Welcome message (supported color tags: {default}, {darkred}, {green}, {lightgreen}, {blue} {olive}, {lime}, {red}, {purple}, {grey}, {yellow}, {lightblue}, {darkblue}, {pink}, {lightred})", _);
-	g_hChecker = AutoExecConfig_CreateConVar("ck_zone_checker", "5.0", "The duration in seconds when the beams around zones are refreshed.", _);
-	g_hZoneDisplayType = AutoExecConfig_CreateConVar("ck_zone_drawstyle", "0", "0 = Do not display zones, 1 = display the lower edges of zones, 2 = display whole zones", _);
-	g_hZonesToDisplay = AutoExecConfig_CreateConVar("ck_zone_drawzones", "1", "Which zones are visible for players. 1 = draw start & end zones, 2 = draw start, end, stage and bonus zones, 3 = draw all zones.", _);
+	g_hWelcomeMsg = AutoExecConfig_CreateConVar("ck_welcome_msg", "{yellow}>>{default} {grey}Welcome! This server is using {lime}SurfTimer", "Welcome message (supported color tags: {default}, {darkred}, {green}, {lightgreen}, {blue} {olive}, {lime}, {red}, {purple}, {grey}, {yellow}, {lightblue}, {darkblue}, {pink}, {lightred})");
+	g_hChecker = AutoExecConfig_CreateConVar("ck_zone_checker", "5.0", "The duration in seconds when the beams around zones are refreshed.");
+	g_hZoneDisplayType = AutoExecConfig_CreateConVar("ck_zone_drawstyle", "0", "0 = Do not display zones, 1 = display the lower edges of zones, 2 = display whole zones");
+	g_hZonesToDisplay = AutoExecConfig_CreateConVar("ck_zone_drawzones", "1", "Which zones are visible for players. 1 = draw start & end zones, 2 = draw start, end, stage and bonus zones, 3 = draw all zones.");
 	g_hSpawnToStartZone = AutoExecConfig_CreateConVar("ck_spawn_to_start_zone", "1.0", "1 = Automatically spawn to the start zone when the client joins the team.", _, true, 0.0, true, 1.0);
 	g_hSoundEnabled = AutoExecConfig_CreateConVar("ck_startzone_sound_enabled", "1.0", "Enable the sound after leaving the start zone.", _, true, 0.0, true, 1.0);
-	g_hSoundPath = AutoExecConfig_CreateConVar("ck_startzone_sound_path", "buttons\\button3.wav", "The path to the sound file that plays after the client leaves the start zone..", _);
+	g_hSoundPath = AutoExecConfig_CreateConVar("ck_startzone_sound_path", "buttons\\button3.wav", "The path to the sound file that plays after the client leaves the start zone..");
 	g_hAnnounceRank = AutoExecConfig_CreateConVar("ck_min_rank_announce", "0", "Higher ranks than this won't be announced to the everyone on the server. 0 = Announce all records.", _, true, 0.0);
 	g_hAnnounceRecord = AutoExecConfig_CreateConVar("ck_chat_record_type", "0", "0: Announce all times to chat, 1: Only announce PB's to chat, 2: Only announce SR's to chat", _, true, 0.0, true, 2.0);
 	g_hForceCT = AutoExecConfig_CreateConVar("ck_force_players_ct", "0", "Forces all players to join the CT team.", _, true, 0.0, true, 1.0);
 	g_hChatSpamFilter = AutoExecConfig_CreateConVar("ck_chat_spamprotection_time", "1.0", "The frequency in seconds that players are allowed to send chat messages. 0.0 = No chat cap.", _, true, 0.0);
-	g_henableChatProcessing = AutoExecConfig_CreateConVar("ck_chat_enable", "1", "(1 / 0) Enable or disable SurfTimers chat processing.", _);
+	g_henableChatProcessing = AutoExecConfig_CreateConVar("ck_chat_enable", "1", "(1 / 0) Enable or disable SurfTimers chat processing.");
 	g_hMultiServerMapcycle = AutoExecConfig_CreateConVar("ck_multi_server_mapcycle", "0", "0 = Use mapcycle.txt to load servers maps, 1 = use configs/surftimer/multi_server_mapcycle.txt to load maps", _, true, 0.0, true, 1.0);
 	g_hDBMapcycle = AutoExecConfig_CreateConVar("ck_db_mapcycle", "1", "0 = use non-db map cycles, 1 use maps from ck_maptier", _, true, 0.0, true, 1.0);
 	g_hDoubleRestartCommand = AutoExecConfig_CreateConVar("ck_double_restart_command", "1", "(1 / 0) Requires 2 successive !r commands to restart the player to prevent accidental usage.", _, true, 0.0, true, 1.0);
@@ -167,13 +167,13 @@ void CreateConVars()
 	HookConVarChange(g_hPointSystem, OnSettingChanged);
 	g_hPlayerSkinChange = AutoExecConfig_CreateConVar("ck_custom_models", "1", "on/off - Allows SurfTimer to change the models of players and bots", _, true, 0.0, true, 1.0);
 	HookConVarChange(g_hPlayerSkinChange, OnSettingChanged);
-	g_hReplayBotPlayerModel = AutoExecConfig_CreateConVar("ck_replay_bot_skin", "models/player/tm_professional_var1.mdl", "Replay pro bot skin", _);
+	g_hReplayBotPlayerModel = AutoExecConfig_CreateConVar("ck_replay_bot_skin", "models/player/tm_professional_var1.mdl", "Replay pro bot skin");
 	HookConVarChange(g_hReplayBotPlayerModel, OnSettingChanged);
-	g_hReplayBotArmModel = AutoExecConfig_CreateConVar("ck_replay_bot_arm_skin", "models/weapons/t_arms_professional.mdl", "Replay pro bot arm skin", _);
+	g_hReplayBotArmModel = AutoExecConfig_CreateConVar("ck_replay_bot_arm_skin", "models/weapons/t_arms_professional.mdl", "Replay pro bot arm skin");
 	HookConVarChange(g_hReplayBotArmModel, OnSettingChanged);
-	g_hPlayerModel = AutoExecConfig_CreateConVar("ck_player_skin", "models/player/ctm_sas_varianta.mdl", "Player skin", _);
+	g_hPlayerModel = AutoExecConfig_CreateConVar("ck_player_skin", "models/player/ctm_sas_varianta.mdl", "Player skin");
 	HookConVarChange(g_hPlayerModel, OnSettingChanged);
-	g_hArmModel = AutoExecConfig_CreateConVar("ck_player_arm_skin", "models/weapons/ct_arms_sas.mdl", "Player arm skin", _);
+	g_hArmModel = AutoExecConfig_CreateConVar("ck_player_arm_skin", "models/weapons/ct_arms_sas.mdl", "Player arm skin");
 	HookConVarChange(g_hArmModel, OnSettingChanged);
 	g_hAutoBhopConVar = AutoExecConfig_CreateConVar("ck_auto_bhop", "1", "on/off - AutoBhop on surf_ maps", _, true, 0.0, true, 1.0);
 	HookConVarChange(g_hAutoBhopConVar, OnSettingChanged);
@@ -194,69 +194,69 @@ void CreateConVars()
 	g_hWrcpBot = AutoExecConfig_CreateConVar("ck_wrcp_bot", "1", "on/off - Bots mimic the local stage records", _, true, 0.0, true, 1.0);
 	HookConVarChange(g_hWrcpBot, OnSettingChanged);
 
-	g_hReplayBotColor = AutoExecConfig_CreateConVar("ck_replay_bot_color", "52 91 248", "The default replay bot color - Format: \"red green blue\" from 0 - 255.", _);
+	g_hReplayBotColor = AutoExecConfig_CreateConVar("ck_replay_bot_color", "52 91 248", "The default replay bot color - Format: \"red green blue\" from 0 - 255.");
 	HookConVarChange(g_hReplayBotColor, OnSettingChanged);
 	char szRBotColor[256];
 	GetConVarString(g_hReplayBotColor, szRBotColor, 256);
 	GetRGBColor(0, szRBotColor);
 
-	g_hBonusBotColor = AutoExecConfig_CreateConVar("ck_bonus_bot_color", "255 255 20", "The bonus replay bot color - Format: \"red green blue\" from 0 - 255.", _);
+	g_hBonusBotColor = AutoExecConfig_CreateConVar("ck_bonus_bot_color", "255 255 20", "The bonus replay bot color - Format: \"red green blue\" from 0 - 255.");
 	HookConVarChange(g_hBonusBotColor, OnSettingChanged);
 	szRBotColor = "";
 	GetConVarString(g_hBonusBotColor, szRBotColor, 256);
 	GetRGBColor(1, szRBotColor);
 
-	g_hzoneStartColor = AutoExecConfig_CreateConVar("ck_zone_startcolor", "000 255 000", "The color of START zones \"red green blue\" from 0 - 255", _);
+	g_hzoneStartColor = AutoExecConfig_CreateConVar("ck_zone_startcolor", "000 255 000", "The color of START zones \"red green blue\" from 0 - 255");
 	GetConVarString(g_hzoneStartColor, g_szZoneColors[1], 24);
 	StringRGBtoInt(g_szZoneColors[1], g_iZoneColors[1]);
 	HookConVarChange(g_hzoneStartColor, OnSettingChanged);
 
-	g_hzoneEndColor = AutoExecConfig_CreateConVar("ck_zone_endcolor", "255 000 000", "The color of END zones \"red green blue\" from 0 - 255", _);
+	g_hzoneEndColor = AutoExecConfig_CreateConVar("ck_zone_endcolor", "255 000 000", "The color of END zones \"red green blue\" from 0 - 255");
 	GetConVarString(g_hzoneEndColor, g_szZoneColors[2], 24);
 	StringRGBtoInt(g_szZoneColors[2], g_iZoneColors[2]);
 	HookConVarChange(g_hzoneEndColor, OnSettingChanged);
 
-	g_hzoneCheckerColor = AutoExecConfig_CreateConVar("ck_zone_checkercolor", "255 255 000", "The color of CHECKER zones \"red green blue\" from 0 - 255", _);
+	g_hzoneCheckerColor = AutoExecConfig_CreateConVar("ck_zone_checkercolor", "255 255 000", "The color of CHECKER zones \"red green blue\" from 0 - 255");
 	GetConVarString(g_hzoneCheckerColor, g_szZoneColors[10], 24);
 	StringRGBtoInt(g_szZoneColors[10], g_iZoneColors[10]);
 	HookConVarChange(g_hzoneCheckerColor, OnSettingChanged);
 
-	g_hzoneBonusStartColor = AutoExecConfig_CreateConVar("ck_zone_bonusstartcolor", "000 255 255", "The color of BONUS START zones \"red green blue\" from 0 - 255", _);
+	g_hzoneBonusStartColor = AutoExecConfig_CreateConVar("ck_zone_bonusstartcolor", "000 255 255", "The color of BONUS START zones \"red green blue\" from 0 - 255");
 	GetConVarString(g_hzoneBonusStartColor, g_szZoneColors[3], 24);
 	StringRGBtoInt(g_szZoneColors[3], g_iZoneColors[3]);
 	HookConVarChange(g_hzoneBonusStartColor, OnSettingChanged);
 
-	g_hzoneBonusEndColor = AutoExecConfig_CreateConVar("ck_zone_bonusendcolor", "255 000 255", "The color of BONUS END zones \"red green blue\" from 0 - 255", _);
+	g_hzoneBonusEndColor = AutoExecConfig_CreateConVar("ck_zone_bonusendcolor", "255 000 255", "The color of BONUS END zones \"red green blue\" from 0 - 255");
 	GetConVarString(g_hzoneBonusEndColor, g_szZoneColors[4], 24);
 	StringRGBtoInt(g_szZoneColors[4], g_iZoneColors[4]);
 	HookConVarChange(g_hzoneBonusEndColor, OnSettingChanged);
 
-	g_hzoneStageColor = AutoExecConfig_CreateConVar("ck_zone_stagecolor", "000 000 255", "The color of STAGE zones \"red green blue\" from 0 - 255", _);
+	g_hzoneStageColor = AutoExecConfig_CreateConVar("ck_zone_stagecolor", "000 000 255", "The color of STAGE zones \"red green blue\" from 0 - 255");
 	GetConVarString(g_hzoneStageColor, g_szZoneColors[5], 24);
 	StringRGBtoInt(g_szZoneColors[5], g_iZoneColors[5]);
 	HookConVarChange(g_hzoneStageColor, OnSettingChanged);
 
-	g_hzoneCheckpointColor = AutoExecConfig_CreateConVar("ck_zone_checkpointcolor", "000 000 255", "The color of CHECKPOINT zones \"red green blue\" from 0 - 255", _);
+	g_hzoneCheckpointColor = AutoExecConfig_CreateConVar("ck_zone_checkpointcolor", "000 000 255", "The color of CHECKPOINT zones \"red green blue\" from 0 - 255");
 	GetConVarString(g_hzoneCheckpointColor, g_szZoneColors[6], 24);
 	StringRGBtoInt(g_szZoneColors[6], g_iZoneColors[6]);
 	HookConVarChange(g_hzoneCheckpointColor, OnSettingChanged);
 
-	g_hzoneSpeedColor = AutoExecConfig_CreateConVar("ck_zone_speedcolor", "255 000 000", "The color of SPEED zones \"red green blue\" from 0 - 255", _);
+	g_hzoneSpeedColor = AutoExecConfig_CreateConVar("ck_zone_speedcolor", "255 000 000", "The color of SPEED zones \"red green blue\" from 0 - 255");
 	GetConVarString(g_hzoneSpeedColor, g_szZoneColors[7], 24);
 	StringRGBtoInt(g_szZoneColors[7], g_iZoneColors[7]);
 	HookConVarChange(g_hzoneSpeedColor, OnSettingChanged);
 
-	g_hzoneTeleToStartColor = AutoExecConfig_CreateConVar("ck_zone_teletostartcolor", "255 255 000", "The color of TELETOSTART zones \"red green blue\" from 0 - 255", _);
+	g_hzoneTeleToStartColor = AutoExecConfig_CreateConVar("ck_zone_teletostartcolor", "255 255 000", "The color of TELETOSTART zones \"red green blue\" from 0 - 255");
 	GetConVarString(g_hzoneTeleToStartColor, g_szZoneColors[8], 24);
 	StringRGBtoInt(g_szZoneColors[8], g_iZoneColors[8]);
 	HookConVarChange(g_hzoneTeleToStartColor, OnSettingChanged);
 
-	g_hzoneValidatorColor = AutoExecConfig_CreateConVar("ck_zone_validatorcolor", "255 255 255", "The color of VALIDATOR zones \"red green blue\" from 0 - 255", _);
+	g_hzoneValidatorColor = AutoExecConfig_CreateConVar("ck_zone_validatorcolor", "255 255 255", "The color of VALIDATOR zones \"red green blue\" from 0 - 255");
 	GetConVarString(g_hzoneValidatorColor, g_szZoneColors[9], 24);
 	StringRGBtoInt(g_szZoneColors[9], g_iZoneColors[9]);
 	HookConVarChange(g_hzoneValidatorColor, OnSettingChanged);
 
-	g_hzoneStopColor = AutoExecConfig_CreateConVar("ck_zone_stopcolor", "000 000 000", "The color of CHECKER zones \"red green blue\" from 0 - 255", _);
+	g_hzoneStopColor = AutoExecConfig_CreateConVar("ck_zone_stopcolor", "000 000 000", "The color of CHECKER zones \"red green blue\" from 0 - 255");
 	GetConVarString(g_hzoneStopColor, g_szZoneColors[0], 24);
 	StringRGBtoInt(g_szZoneColors[0], g_iZoneColors[0]);
 	HookConVarChange(g_hzoneStopColor, OnSettingChanged);
@@ -264,7 +264,7 @@ void CreateConVars()
 	bool validFlag;
 	char szFlag[24];
 	AdminFlag bufferFlag;
-	g_hAdminMenuFlag = AutoExecConfig_CreateConVar("ck_adminmenu_flag", "z", "Admin flag required to open the !ckadmin menu. Invalid or not set, requires flag z. Requires a server restart.", _);
+	g_hAdminMenuFlag = AutoExecConfig_CreateConVar("ck_adminmenu_flag", "z", "Admin flag required to open the !ckadmin menu. Invalid or not set, requires flag z. Requires a server restart.");
 	GetConVarString(g_hAdminMenuFlag, szFlag, 24);
 	validFlag = FindFlagByChar(szFlag[0], bufferFlag);
 	if (!validFlag)
@@ -278,7 +278,7 @@ void CreateConVars()
 	}
 	HookConVarChange(g_hAdminMenuFlag, OnSettingChanged);
 
-	g_hZonerFlag = AutoExecConfig_CreateConVar("ck_zoner_flag", "z", "Zoner status will automatically be granted to players with this flag. If the convar is invalid or not set, z (root) will be used by default.", _);
+	g_hZonerFlag = AutoExecConfig_CreateConVar("ck_zoner_flag", "z", "Zoner status will automatically be granted to players with this flag. If the convar is invalid or not set, z (root) will be used by default.");
 	GetConVarString(g_hZonerFlag, szFlag, 24);
 	validFlag = FindFlagByChar(szFlag[0], bufferFlag);
 	if (!validFlag)
@@ -296,7 +296,7 @@ void CreateConVars()
 	g_hGravityFix = AutoExecConfig_CreateConVar("ck_gravityfix_enable", "1", "Enables/Disables trigger_gravity fix", _, true, 0.0, true, 1.0);
 
 	// VIP ConVars
-	g_hAutoVipFlag = AutoExecConfig_CreateConVar("ck_vip_flag", "a", "VIP status will be automatically granted to players with this flag. If the convar is invalid or not set, a (reservation) will be used by default.", _);
+	g_hAutoVipFlag = AutoExecConfig_CreateConVar("ck_vip_flag", "a", "VIP status will be automatically granted to players with this flag. If the convar is invalid or not set, a (reservation) will be used by default.");
 	GetConVarString(g_hAutoVipFlag, szFlag, 24);
 	validFlag = FindFlagByChar(szFlag[0], bufferFlag);
 	if (!validFlag)

--- a/addons/sourcemod/scripting/surftimer/convars.sp
+++ b/addons/sourcemod/scripting/surftimer/convars.sp
@@ -122,141 +122,141 @@ void CreateConVars()
 	AutoExecConfig_SetCreateFile(true);
 	AutoExecConfig_SetFile("surftimer");
 
-	g_hChatPrefix = AutoExecConfig_CreateConVar("ck_chat_prefix", "{lime}SurfTimer {default}|", "Determines the prefix used for chat messages", FCVAR_NOTIFY);
-	g_hConnectMsg = AutoExecConfig_CreateConVar("ck_connect_msg", "1", "on/off - Enables a player connect message with country tag", FCVAR_NOTIFY, true, 0.0, true, 1.0);
-	g_hAllowRoundEndCvar = AutoExecConfig_CreateConVar("ck_round_end", "0", "on/off - Allows to end the current round", FCVAR_NOTIFY, true, 0.0, true, 1.0);
-	g_hDisconnectMsg = AutoExecConfig_CreateConVar("ck_disconnect_msg", "1", "on/off - Enables a player disconnect message in chat", FCVAR_NOTIFY, true, 0.0, true, 1.0);
-	g_hMapEnd = AutoExecConfig_CreateConVar("ck_map_end", "1", "on/off - Allows map changes after the timelimit has run out (mp_timelimit must be greater than 0)", FCVAR_NOTIFY, true, 0.0, true, 1.0);
-	g_hColoredNames = AutoExecConfig_CreateConVar("ck_colored_chatnames", "1", "on/off Colors players names based on their rank in chat.", FCVAR_NOTIFY, true, 0.0, true, 1.0);
-	g_hNoClipS = AutoExecConfig_CreateConVar("ck_noclip", "1", "on/off - Allows players to use noclip", FCVAR_NOTIFY, true, 0.0, true, 1.0);
-	g_hGoToServer = AutoExecConfig_CreateConVar("ck_goto", "1", "on/off - Allows players to use the !goto command", FCVAR_NOTIFY, true, 0.0, true, 1.0);
-	g_hCommandToEnd = AutoExecConfig_CreateConVar("ck_end", "1", "on/off - Allows players to use the !end command", FCVAR_NOTIFY, true, 0.0, true, 1.0);
-	g_hCvarGodMode = AutoExecConfig_CreateConVar("ck_godmode", "1", "on/off - Godmode", FCVAR_NOTIFY, true, 0.0, true, 1.0);
-	g_hPauseServerside = AutoExecConfig_CreateConVar("ck_pause", "1", "on/off - Allows players to use the !pause command", FCVAR_NOTIFY, true, 0.0, true, 1.0);
-	g_hcvarRestore = AutoExecConfig_CreateConVar("ck_restore", "1", "on/off - Restoring of time and last position after reconnect", FCVAR_NOTIFY, true, 0.0, true, 1.0);
-	g_hAttackSpamProtection = AutoExecConfig_CreateConVar("ck_attack_spam_protection", "1", "on/off - max 40 shots; +5 new/extra shots per minute; 1 he/flash counts like 9 shots", FCVAR_NOTIFY, true, 0.0, true, 1.0);
-	g_hRadioCommands = AutoExecConfig_CreateConVar("ck_use_radio", "0", "on/off - Allows players to use radio commands", FCVAR_NOTIFY, true, 0.0, true, 1.0);
-	g_hAutohealing_Hp = AutoExecConfig_CreateConVar("ck_autoheal", "50", "Sets HP amount for autohealing (requires ck_godmode 0)", FCVAR_NOTIFY, true, 0.0, true, 100.0);
-	g_hDynamicTimelimit = AutoExecConfig_CreateConVar("ck_dynamic_timelimit", "0", "on/off - Sets a suitable timelimit by calculating the average run time (This method requires ck_map_end 1, greater than 5 map times and a default timelimit in your server config for maps with less than 5 times", FCVAR_NOTIFY, true, 0.0, true, 1.0);
-	g_hWelcomeMsg = AutoExecConfig_CreateConVar("ck_welcome_msg", "{yellow}>>{default} {grey}Welcome! This server is using {lime}SurfTimer", "Welcome message (supported color tags: {default}, {darkred}, {green}, {lightgreen}, {blue} {olive}, {lime}, {red}, {purple}, {grey}, {yellow}, {lightblue}, {darkblue}, {pink}, {lightred})", FCVAR_NOTIFY);
-	g_hChecker = AutoExecConfig_CreateConVar("ck_zone_checker", "5.0", "The duration in seconds when the beams around zones are refreshed.", FCVAR_NOTIFY);
-	g_hZoneDisplayType = AutoExecConfig_CreateConVar("ck_zone_drawstyle", "0", "0 = Do not display zones, 1 = display the lower edges of zones, 2 = display whole zones", FCVAR_NOTIFY);
-	g_hZonesToDisplay = AutoExecConfig_CreateConVar("ck_zone_drawzones", "1", "Which zones are visible for players. 1 = draw start & end zones, 2 = draw start, end, stage and bonus zones, 3 = draw all zones.", FCVAR_NOTIFY);
-	g_hSpawnToStartZone = AutoExecConfig_CreateConVar("ck_spawn_to_start_zone", "1.0", "1 = Automatically spawn to the start zone when the client joins the team.", FCVAR_NOTIFY, true, 0.0, true, 1.0);
-	g_hSoundEnabled = AutoExecConfig_CreateConVar("ck_startzone_sound_enabled", "1.0", "Enable the sound after leaving the start zone.", FCVAR_NOTIFY, true, 0.0, true, 1.0);
-	g_hSoundPath = AutoExecConfig_CreateConVar("ck_startzone_sound_path", "buttons\\button3.wav", "The path to the sound file that plays after the client leaves the start zone..", FCVAR_NOTIFY);
-	g_hAnnounceRank = AutoExecConfig_CreateConVar("ck_min_rank_announce", "0", "Higher ranks than this won't be announced to the everyone on the server. 0 = Announce all records.", FCVAR_NOTIFY, true, 0.0);
-	g_hAnnounceRecord = AutoExecConfig_CreateConVar("ck_chat_record_type", "0", "0: Announce all times to chat, 1: Only announce PB's to chat, 2: Only announce SR's to chat", FCVAR_NOTIFY, true, 0.0, true, 2.0);
-	g_hForceCT = AutoExecConfig_CreateConVar("ck_force_players_ct", "0", "Forces all players to join the CT team.", FCVAR_NOTIFY, true, 0.0, true, 1.0);
-	g_hChatSpamFilter = AutoExecConfig_CreateConVar("ck_chat_spamprotection_time", "1.0", "The frequency in seconds that players are allowed to send chat messages. 0.0 = No chat cap.", FCVAR_NOTIFY, true, 0.0);
-	g_henableChatProcessing = AutoExecConfig_CreateConVar("ck_chat_enable", "1", "(1 / 0) Enable or disable SurfTimers chat processing.", FCVAR_NOTIFY);
-	g_hMultiServerMapcycle = AutoExecConfig_CreateConVar("ck_multi_server_mapcycle", "0", "0 = Use mapcycle.txt to load servers maps, 1 = use configs/surftimer/multi_server_mapcycle.txt to load maps", FCVAR_NOTIFY, true, 0.0, true, 1.0);
-	g_hDBMapcycle = AutoExecConfig_CreateConVar("ck_db_mapcycle", "1", "0 = use non-db map cycles, 1 use maps from ck_maptier", FCVAR_NOTIFY, true, 0.0, true, 1.0);
-	g_hDoubleRestartCommand = AutoExecConfig_CreateConVar("ck_double_restart_command", "1", "(1 / 0) Requires 2 successive !r commands to restart the player to prevent accidental usage.", FCVAR_NOTIFY, true, 0.0, true, 1.0);
-	g_hBackupReplays = AutoExecConfig_CreateConVar("ck_replay_backup", "1", "(1 / 0) Back up replay files, when they are being replaced", FCVAR_NOTIFY, true, 0.0, true, 1.0);
-	g_hReplaceReplayTime = 	AutoExecConfig_CreateConVar("ck_replay_replace_faster", "1", "(1 / 0) Replace record bots if a players time is faster than the bot, even if the time is not a server record.", FCVAR_NOTIFY, true, 0.0, true, 1.0);
-	g_hTeleToStartWhenSettingsLoaded = AutoExecConfig_CreateConVar("ck_teleportclientstostart", "1", "(1 / 0) Teleport players automatically back to the start zone, when their settings have been loaded.", FCVAR_NOTIFY, true, 0.0, true, 1.0);
-	g_drDeleteSecurity = AutoExecConfig_CreateConVar("ck_dr_delete_security", "1", "(1 / 0) Enable/Disable delete security for !dr command", FCVAR_NOTIFY, true, 0.0, true, 1.0);
-	g_iAdminCountryTags = AutoExecConfig_CreateConVar("ck_admin_country_tags", "0", "(1 / 0) Enable/Disable country tags for admins", FCVAR_NOTIFY, true, 0.0, true, 1.0);
-	g_replayBotDelay = AutoExecConfig_CreateConVar("ck_replay_bot_delay", "10", "Delay in seconds after initial mapstart after the bots join the server", FCVAR_NOTIFY, true, 10.0);
-	g_iHintsInterval = AutoExecConfig_CreateConVar("ck_hints_interval", "240", "Seconds between two hints. Leave empty or set to 0 to disable", FCVAR_NOTIFY, true, 0.0);
-	g_bHintsRandomOrder = AutoExecConfig_CreateConVar("ck_hints_random_order", "1", "(1 / 0) Enable/Disable hints shown in a random order", FCVAR_NOTIFY, true, 0.0, true, 1.0);
-	g_hOverrideClantag = AutoExecConfig_CreateConVar("ck_override_clantag", "1", "Override player's clantag", FCVAR_NOTIFY, true, 0.0, true, 1.0);
+	g_hChatPrefix = AutoExecConfig_CreateConVar("ck_chat_prefix", "{lime}SurfTimer {default}|", "Determines the prefix used for chat messages");
+	g_hConnectMsg = AutoExecConfig_CreateConVar("ck_connect_msg", "1", "on/off - Enables a player connect message with country tag", _,true, 0.0, true, 1.0);
+	g_hAllowRoundEndCvar = AutoExecConfig_CreateConVar("ck_round_end", "0", "on/off - Allows to end the current round", _, true, 0.0, true, 1.0);
+	g_hDisconnectMsg = AutoExecConfig_CreateConVar("ck_disconnect_msg", "1", "on/off - Enables a player disconnect message in chat", _, true, 0.0, true, 1.0);
+	g_hMapEnd = AutoExecConfig_CreateConVar("ck_map_end", "1", "on/off - Allows map changes after the timelimit has run out (mp_timelimit must be greater than 0)", _, true, 0.0, true, 1.0);
+	g_hColoredNames = AutoExecConfig_CreateConVar("ck_colored_chatnames", "1", "on/off Colors players names based on their rank in chat.", _, true, 0.0, true, 1.0);
+	g_hNoClipS = AutoExecConfig_CreateConVar("ck_noclip", "1", "on/off - Allows players to use noclip", _, true, 0.0, true, 1.0);
+	g_hGoToServer = AutoExecConfig_CreateConVar("ck_goto", "1", "on/off - Allows players to use the !goto command", _, true, 0.0, true, 1.0);
+	g_hCommandToEnd = AutoExecConfig_CreateConVar("ck_end", "1", "on/off - Allows players to use the !end command", _, true, 0.0, true, 1.0);
+	g_hCvarGodMode = AutoExecConfig_CreateConVar("ck_godmode", "1", "on/off - Godmode", _, true, 0.0, true, 1.0);
+	g_hPauseServerside = AutoExecConfig_CreateConVar("ck_pause", "1", "on/off - Allows players to use the !pause command", _, true, 0.0, true, 1.0);
+	g_hcvarRestore = AutoExecConfig_CreateConVar("ck_restore", "1", "on/off - Restoring of time and last position after reconnect", _, true, 0.0, true, 1.0);
+	g_hAttackSpamProtection = AutoExecConfig_CreateConVar("ck_attack_spam_protection", "1", "on/off - max 40 shots; +5 new/extra shots per minute; 1 he/flash counts like 9 shots", _, true, 0.0, true, 1.0);
+	g_hRadioCommands = AutoExecConfig_CreateConVar("ck_use_radio", "0", "on/off - Allows players to use radio commands", _, true, 0.0, true, 1.0);
+	g_hAutohealing_Hp = AutoExecConfig_CreateConVar("ck_autoheal", "50", "Sets HP amount for autohealing (requires ck_godmode 0)", _, true, 0.0, true, 100.0);
+	g_hDynamicTimelimit = AutoExecConfig_CreateConVar("ck_dynamic_timelimit", "0", "on/off - Sets a suitable timelimit by calculating the average run time (This method requires ck_map_end 1, greater than 5 map times and a default timelimit in your server config for maps with less than 5 times", _, true, 0.0, true, 1.0);
+	g_hWelcomeMsg = AutoExecConfig_CreateConVar("ck_welcome_msg", "{yellow}>>{default} {grey}Welcome! This server is using {lime}SurfTimer", "Welcome message (supported color tags: {default}, {darkred}, {green}, {lightgreen}, {blue} {olive}, {lime}, {red}, {purple}, {grey}, {yellow}, {lightblue}, {darkblue}, {pink}, {lightred})", _);
+	g_hChecker = AutoExecConfig_CreateConVar("ck_zone_checker", "5.0", "The duration in seconds when the beams around zones are refreshed.", _);
+	g_hZoneDisplayType = AutoExecConfig_CreateConVar("ck_zone_drawstyle", "0", "0 = Do not display zones, 1 = display the lower edges of zones, 2 = display whole zones", _);
+	g_hZonesToDisplay = AutoExecConfig_CreateConVar("ck_zone_drawzones", "1", "Which zones are visible for players. 1 = draw start & end zones, 2 = draw start, end, stage and bonus zones, 3 = draw all zones.", _);
+	g_hSpawnToStartZone = AutoExecConfig_CreateConVar("ck_spawn_to_start_zone", "1.0", "1 = Automatically spawn to the start zone when the client joins the team.", _, true, 0.0, true, 1.0);
+	g_hSoundEnabled = AutoExecConfig_CreateConVar("ck_startzone_sound_enabled", "1.0", "Enable the sound after leaving the start zone.", _, true, 0.0, true, 1.0);
+	g_hSoundPath = AutoExecConfig_CreateConVar("ck_startzone_sound_path", "buttons\\button3.wav", "The path to the sound file that plays after the client leaves the start zone..", _);
+	g_hAnnounceRank = AutoExecConfig_CreateConVar("ck_min_rank_announce", "0", "Higher ranks than this won't be announced to the everyone on the server. 0 = Announce all records.", _, true, 0.0);
+	g_hAnnounceRecord = AutoExecConfig_CreateConVar("ck_chat_record_type", "0", "0: Announce all times to chat, 1: Only announce PB's to chat, 2: Only announce SR's to chat", _, true, 0.0, true, 2.0);
+	g_hForceCT = AutoExecConfig_CreateConVar("ck_force_players_ct", "0", "Forces all players to join the CT team.", _, true, 0.0, true, 1.0);
+	g_hChatSpamFilter = AutoExecConfig_CreateConVar("ck_chat_spamprotection_time", "1.0", "The frequency in seconds that players are allowed to send chat messages. 0.0 = No chat cap.", _, true, 0.0);
+	g_henableChatProcessing = AutoExecConfig_CreateConVar("ck_chat_enable", "1", "(1 / 0) Enable or disable SurfTimers chat processing.", _);
+	g_hMultiServerMapcycle = AutoExecConfig_CreateConVar("ck_multi_server_mapcycle", "0", "0 = Use mapcycle.txt to load servers maps, 1 = use configs/surftimer/multi_server_mapcycle.txt to load maps", _, true, 0.0, true, 1.0);
+	g_hDBMapcycle = AutoExecConfig_CreateConVar("ck_db_mapcycle", "1", "0 = use non-db map cycles, 1 use maps from ck_maptier", _, true, 0.0, true, 1.0);
+	g_hDoubleRestartCommand = AutoExecConfig_CreateConVar("ck_double_restart_command", "1", "(1 / 0) Requires 2 successive !r commands to restart the player to prevent accidental usage.", _, true, 0.0, true, 1.0);
+	g_hBackupReplays = AutoExecConfig_CreateConVar("ck_replay_backup", "1", "(1 / 0) Back up replay files, when they are being replaced", _, true, 0.0, true, 1.0);
+	g_hReplaceReplayTime = 	AutoExecConfig_CreateConVar("ck_replay_replace_faster", "1", "(1 / 0) Replace record bots if a players time is faster than the bot, even if the time is not a server record.", _, true, 0.0, true, 1.0);
+	g_hTeleToStartWhenSettingsLoaded = AutoExecConfig_CreateConVar("ck_teleportclientstostart", "1", "(1 / 0) Teleport players automatically back to the start zone, when their settings have been loaded.", _, true, 0.0, true, 1.0);
+	g_drDeleteSecurity = AutoExecConfig_CreateConVar("ck_dr_delete_security", "1", "(1 / 0) Enable/Disable delete security for !dr command", _, true, 0.0, true, 1.0);
+	g_iAdminCountryTags = AutoExecConfig_CreateConVar("ck_admin_country_tags", "0", "(1 / 0) Enable/Disable country tags for admins", _, true, 0.0, true, 1.0);
+	g_replayBotDelay = AutoExecConfig_CreateConVar("ck_replay_bot_delay", "10", "Delay in seconds after initial mapstart after the bots join the server", _, true, 10.0);
+	g_iHintsInterval = AutoExecConfig_CreateConVar("ck_hints_interval", "240", "Seconds between two hints. Leave empty or set to 0 to disable", _, true, 0.0);
+	g_bHintsRandomOrder = AutoExecConfig_CreateConVar("ck_hints_random_order", "1", "(1 / 0) Enable/Disable hints shown in a random order", _, true, 0.0, true, 1.0);
+	g_hOverrideClantag = AutoExecConfig_CreateConVar("ck_override_clantag", "1", "Override player's clantag", _, true, 0.0, true, 1.0);
 
-	g_hPointSystem = AutoExecConfig_CreateConVar("ck_point_system", "1", "on/off - Player point system", FCVAR_NOTIFY, true, 0.0, true, 1.0);
+	g_hPointSystem = AutoExecConfig_CreateConVar("ck_point_system", "1", "on/off - Player point system", _, true, 0.0, true, 1.0);
 	HookConVarChange(g_hPointSystem, OnSettingChanged);
-	g_hPlayerSkinChange = AutoExecConfig_CreateConVar("ck_custom_models", "1", "on/off - Allows SurfTimer to change the models of players and bots", FCVAR_NOTIFY, true, 0.0, true, 1.0);
+	g_hPlayerSkinChange = AutoExecConfig_CreateConVar("ck_custom_models", "1", "on/off - Allows SurfTimer to change the models of players and bots", _, true, 0.0, true, 1.0);
 	HookConVarChange(g_hPlayerSkinChange, OnSettingChanged);
-	g_hReplayBotPlayerModel = AutoExecConfig_CreateConVar("ck_replay_bot_skin", "models/player/tm_professional_var1.mdl", "Replay pro bot skin", FCVAR_NOTIFY);
+	g_hReplayBotPlayerModel = AutoExecConfig_CreateConVar("ck_replay_bot_skin", "models/player/tm_professional_var1.mdl", "Replay pro bot skin", _);
 	HookConVarChange(g_hReplayBotPlayerModel, OnSettingChanged);
-	g_hReplayBotArmModel = AutoExecConfig_CreateConVar("ck_replay_bot_arm_skin", "models/weapons/t_arms_professional.mdl", "Replay pro bot arm skin", FCVAR_NOTIFY);
+	g_hReplayBotArmModel = AutoExecConfig_CreateConVar("ck_replay_bot_arm_skin", "models/weapons/t_arms_professional.mdl", "Replay pro bot arm skin", _);
 	HookConVarChange(g_hReplayBotArmModel, OnSettingChanged);
-	g_hPlayerModel = AutoExecConfig_CreateConVar("ck_player_skin", "models/player/ctm_sas_varianta.mdl", "Player skin", FCVAR_NOTIFY);
+	g_hPlayerModel = AutoExecConfig_CreateConVar("ck_player_skin", "models/player/ctm_sas_varianta.mdl", "Player skin", _);
 	HookConVarChange(g_hPlayerModel, OnSettingChanged);
-	g_hArmModel = AutoExecConfig_CreateConVar("ck_player_arm_skin", "models/weapons/ct_arms_sas.mdl", "Player arm skin", FCVAR_NOTIFY);
+	g_hArmModel = AutoExecConfig_CreateConVar("ck_player_arm_skin", "models/weapons/ct_arms_sas.mdl", "Player arm skin", _);
 	HookConVarChange(g_hArmModel, OnSettingChanged);
-	g_hAutoBhopConVar = AutoExecConfig_CreateConVar("ck_auto_bhop", "1", "on/off - AutoBhop on surf_ maps", FCVAR_NOTIFY, true, 0.0, true, 1.0);
+	g_hAutoBhopConVar = AutoExecConfig_CreateConVar("ck_auto_bhop", "1", "on/off - AutoBhop on surf_ maps", _, true, 0.0, true, 1.0);
 	HookConVarChange(g_hAutoBhopConVar, OnSettingChanged);
-	g_hCleanWeapons = AutoExecConfig_CreateConVar("ck_clean_weapons", "1", "on/off - Removes all weapons on the ground", FCVAR_NOTIFY, true, 0.0, true, 1.0);
+	g_hCleanWeapons = AutoExecConfig_CreateConVar("ck_clean_weapons", "1", "on/off - Removes all weapons on the ground", _, true, 0.0, true, 1.0);
 	HookConVarChange(g_hCleanWeapons, OnSettingChanged);
-	g_hCountry = AutoExecConfig_CreateConVar("ck_country_tag", "1", "on/off - Country clan tag", FCVAR_NOTIFY, true, 0.0, true, 1.0);
+	g_hCountry = AutoExecConfig_CreateConVar("ck_country_tag", "1", "on/off - Country clan tag", _, true, 0.0, true, 1.0);
 	HookConVarChange(g_hCountry, OnSettingChanged);
-	g_hAutoRespawn = AutoExecConfig_CreateConVar("ck_autorespawn", "1", "on/off - Auto respawn", FCVAR_NOTIFY, true, 0.0, true, 1.0);
+	g_hAutoRespawn = AutoExecConfig_CreateConVar("ck_autorespawn", "1", "on/off - Auto respawn", _, true, 0.0, true, 1.0);
 	HookConVarChange(g_hAutoRespawn, OnSettingChanged);
-	g_hCvarNoBlock = AutoExecConfig_CreateConVar("ck_noblock", "1", "on/off - Player no blocking", FCVAR_NOTIFY, true, 0.0, true, 1.0);
+	g_hCvarNoBlock = AutoExecConfig_CreateConVar("ck_noblock", "1", "on/off - Player no blocking", _, true, 0.0, true, 1.0);
 	HookConVarChange(g_hCvarNoBlock, OnSettingChanged);
-	g_hReplayBot = AutoExecConfig_CreateConVar("ck_replay_bot", "1", "on/off - Bots mimic the local map record", FCVAR_NOTIFY, true, 0.0, true, 1.0);
+	g_hReplayBot = AutoExecConfig_CreateConVar("ck_replay_bot", "1", "on/off - Bots mimic the local map record", _, true, 0.0, true, 1.0);
 	HookConVarChange(g_hReplayBot, OnSettingChanged);
-	g_hBonusBot = AutoExecConfig_CreateConVar("ck_bonus_bot", "1", "on/off - Bots mimic the local bonus record", FCVAR_NOTIFY, true, 0.0, true, 1.0);
+	g_hBonusBot = AutoExecConfig_CreateConVar("ck_bonus_bot", "1", "on/off - Bots mimic the local bonus record", _, true, 0.0, true, 1.0);
 	HookConVarChange(g_hBonusBot, OnSettingChanged);
-	g_hInfoBot = AutoExecConfig_CreateConVar("ck_info_bot", "0", "on/off - provides information about nextmap and timeleft in his player name", FCVAR_NOTIFY, true, 0.0, true, 1.0);
+	g_hInfoBot = AutoExecConfig_CreateConVar("ck_info_bot", "0", "on/off - provides information about nextmap and timeleft in his player name", _, true, 0.0, true, 1.0);
 	HookConVarChange(g_hInfoBot, OnSettingChanged);
-	g_hWrcpBot = AutoExecConfig_CreateConVar("ck_wrcp_bot", "1", "on/off - Bots mimic the local stage records", FCVAR_NOTIFY, true, 0.0, true, 1.0);
+	g_hWrcpBot = AutoExecConfig_CreateConVar("ck_wrcp_bot", "1", "on/off - Bots mimic the local stage records", _, true, 0.0, true, 1.0);
 	HookConVarChange(g_hWrcpBot, OnSettingChanged);
 
-	g_hReplayBotColor = AutoExecConfig_CreateConVar("ck_replay_bot_color", "52 91 248", "The default replay bot color - Format: \"red green blue\" from 0 - 255.", FCVAR_NOTIFY);
+	g_hReplayBotColor = AutoExecConfig_CreateConVar("ck_replay_bot_color", "52 91 248", "The default replay bot color - Format: \"red green blue\" from 0 - 255.", _);
 	HookConVarChange(g_hReplayBotColor, OnSettingChanged);
 	char szRBotColor[256];
 	GetConVarString(g_hReplayBotColor, szRBotColor, 256);
 	GetRGBColor(0, szRBotColor);
 
-	g_hBonusBotColor = AutoExecConfig_CreateConVar("ck_bonus_bot_color", "255 255 20", "The bonus replay bot color - Format: \"red green blue\" from 0 - 255.", FCVAR_NOTIFY);
+	g_hBonusBotColor = AutoExecConfig_CreateConVar("ck_bonus_bot_color", "255 255 20", "The bonus replay bot color - Format: \"red green blue\" from 0 - 255.", _);
 	HookConVarChange(g_hBonusBotColor, OnSettingChanged);
 	szRBotColor = "";
 	GetConVarString(g_hBonusBotColor, szRBotColor, 256);
 	GetRGBColor(1, szRBotColor);
 
-	g_hzoneStartColor = AutoExecConfig_CreateConVar("ck_zone_startcolor", "000 255 000", "The color of START zones \"red green blue\" from 0 - 255", FCVAR_NOTIFY);
+	g_hzoneStartColor = AutoExecConfig_CreateConVar("ck_zone_startcolor", "000 255 000", "The color of START zones \"red green blue\" from 0 - 255", _);
 	GetConVarString(g_hzoneStartColor, g_szZoneColors[1], 24);
 	StringRGBtoInt(g_szZoneColors[1], g_iZoneColors[1]);
 	HookConVarChange(g_hzoneStartColor, OnSettingChanged);
 
-	g_hzoneEndColor = AutoExecConfig_CreateConVar("ck_zone_endcolor", "255 000 000", "The color of END zones \"red green blue\" from 0 - 255", FCVAR_NOTIFY);
+	g_hzoneEndColor = AutoExecConfig_CreateConVar("ck_zone_endcolor", "255 000 000", "The color of END zones \"red green blue\" from 0 - 255", _);
 	GetConVarString(g_hzoneEndColor, g_szZoneColors[2], 24);
 	StringRGBtoInt(g_szZoneColors[2], g_iZoneColors[2]);
 	HookConVarChange(g_hzoneEndColor, OnSettingChanged);
 
-	g_hzoneCheckerColor = AutoExecConfig_CreateConVar("ck_zone_checkercolor", "255 255 000", "The color of CHECKER zones \"red green blue\" from 0 - 255", FCVAR_NOTIFY);
+	g_hzoneCheckerColor = AutoExecConfig_CreateConVar("ck_zone_checkercolor", "255 255 000", "The color of CHECKER zones \"red green blue\" from 0 - 255", _);
 	GetConVarString(g_hzoneCheckerColor, g_szZoneColors[10], 24);
 	StringRGBtoInt(g_szZoneColors[10], g_iZoneColors[10]);
 	HookConVarChange(g_hzoneCheckerColor, OnSettingChanged);
 
-	g_hzoneBonusStartColor = AutoExecConfig_CreateConVar("ck_zone_bonusstartcolor", "000 255 255", "The color of BONUS START zones \"red green blue\" from 0 - 255", FCVAR_NOTIFY);
+	g_hzoneBonusStartColor = AutoExecConfig_CreateConVar("ck_zone_bonusstartcolor", "000 255 255", "The color of BONUS START zones \"red green blue\" from 0 - 255", _);
 	GetConVarString(g_hzoneBonusStartColor, g_szZoneColors[3], 24);
 	StringRGBtoInt(g_szZoneColors[3], g_iZoneColors[3]);
 	HookConVarChange(g_hzoneBonusStartColor, OnSettingChanged);
 
-	g_hzoneBonusEndColor = AutoExecConfig_CreateConVar("ck_zone_bonusendcolor", "255 000 255", "The color of BONUS END zones \"red green blue\" from 0 - 255", FCVAR_NOTIFY);
+	g_hzoneBonusEndColor = AutoExecConfig_CreateConVar("ck_zone_bonusendcolor", "255 000 255", "The color of BONUS END zones \"red green blue\" from 0 - 255", _);
 	GetConVarString(g_hzoneBonusEndColor, g_szZoneColors[4], 24);
 	StringRGBtoInt(g_szZoneColors[4], g_iZoneColors[4]);
 	HookConVarChange(g_hzoneBonusEndColor, OnSettingChanged);
 
-	g_hzoneStageColor = AutoExecConfig_CreateConVar("ck_zone_stagecolor", "000 000 255", "The color of STAGE zones \"red green blue\" from 0 - 255", FCVAR_NOTIFY);
+	g_hzoneStageColor = AutoExecConfig_CreateConVar("ck_zone_stagecolor", "000 000 255", "The color of STAGE zones \"red green blue\" from 0 - 255", _);
 	GetConVarString(g_hzoneStageColor, g_szZoneColors[5], 24);
 	StringRGBtoInt(g_szZoneColors[5], g_iZoneColors[5]);
 	HookConVarChange(g_hzoneStageColor, OnSettingChanged);
 
-	g_hzoneCheckpointColor = AutoExecConfig_CreateConVar("ck_zone_checkpointcolor", "000 000 255", "The color of CHECKPOINT zones \"red green blue\" from 0 - 255", FCVAR_NOTIFY);
+	g_hzoneCheckpointColor = AutoExecConfig_CreateConVar("ck_zone_checkpointcolor", "000 000 255", "The color of CHECKPOINT zones \"red green blue\" from 0 - 255", _);
 	GetConVarString(g_hzoneCheckpointColor, g_szZoneColors[6], 24);
 	StringRGBtoInt(g_szZoneColors[6], g_iZoneColors[6]);
 	HookConVarChange(g_hzoneCheckpointColor, OnSettingChanged);
 
-	g_hzoneSpeedColor = AutoExecConfig_CreateConVar("ck_zone_speedcolor", "255 000 000", "The color of SPEED zones \"red green blue\" from 0 - 255", FCVAR_NOTIFY);
+	g_hzoneSpeedColor = AutoExecConfig_CreateConVar("ck_zone_speedcolor", "255 000 000", "The color of SPEED zones \"red green blue\" from 0 - 255", _);
 	GetConVarString(g_hzoneSpeedColor, g_szZoneColors[7], 24);
 	StringRGBtoInt(g_szZoneColors[7], g_iZoneColors[7]);
 	HookConVarChange(g_hzoneSpeedColor, OnSettingChanged);
 
-	g_hzoneTeleToStartColor = AutoExecConfig_CreateConVar("ck_zone_teletostartcolor", "255 255 000", "The color of TELETOSTART zones \"red green blue\" from 0 - 255", FCVAR_NOTIFY);
+	g_hzoneTeleToStartColor = AutoExecConfig_CreateConVar("ck_zone_teletostartcolor", "255 255 000", "The color of TELETOSTART zones \"red green blue\" from 0 - 255", _);
 	GetConVarString(g_hzoneTeleToStartColor, g_szZoneColors[8], 24);
 	StringRGBtoInt(g_szZoneColors[8], g_iZoneColors[8]);
 	HookConVarChange(g_hzoneTeleToStartColor, OnSettingChanged);
 
-	g_hzoneValidatorColor = AutoExecConfig_CreateConVar("ck_zone_validatorcolor", "255 255 255", "The color of VALIDATOR zones \"red green blue\" from 0 - 255", FCVAR_NOTIFY);
+	g_hzoneValidatorColor = AutoExecConfig_CreateConVar("ck_zone_validatorcolor", "255 255 255", "The color of VALIDATOR zones \"red green blue\" from 0 - 255", _);
 	GetConVarString(g_hzoneValidatorColor, g_szZoneColors[9], 24);
 	StringRGBtoInt(g_szZoneColors[9], g_iZoneColors[9]);
 	HookConVarChange(g_hzoneValidatorColor, OnSettingChanged);
 
-	g_hzoneStopColor = AutoExecConfig_CreateConVar("ck_zone_stopcolor", "000 000 000", "The color of CHECKER zones \"red green blue\" from 0 - 255", FCVAR_NOTIFY);
+	g_hzoneStopColor = AutoExecConfig_CreateConVar("ck_zone_stopcolor", "000 000 000", "The color of CHECKER zones \"red green blue\" from 0 - 255", _);
 	GetConVarString(g_hzoneStopColor, g_szZoneColors[0], 24);
 	StringRGBtoInt(g_szZoneColors[0], g_iZoneColors[0]);
 	HookConVarChange(g_hzoneStopColor, OnSettingChanged);
@@ -264,7 +264,7 @@ void CreateConVars()
 	bool validFlag;
 	char szFlag[24];
 	AdminFlag bufferFlag;
-	g_hAdminMenuFlag = AutoExecConfig_CreateConVar("ck_adminmenu_flag", "z", "Admin flag required to open the !ckadmin menu. Invalid or not set, requires flag z. Requires a server restart.", FCVAR_NOTIFY);
+	g_hAdminMenuFlag = AutoExecConfig_CreateConVar("ck_adminmenu_flag", "z", "Admin flag required to open the !ckadmin menu. Invalid or not set, requires flag z. Requires a server restart.", _);
 	GetConVarString(g_hAdminMenuFlag, szFlag, 24);
 	validFlag = FindFlagByChar(szFlag[0], bufferFlag);
 	if (!validFlag)
@@ -278,7 +278,7 @@ void CreateConVars()
 	}
 	HookConVarChange(g_hAdminMenuFlag, OnSettingChanged);
 
-	g_hZonerFlag = AutoExecConfig_CreateConVar("ck_zoner_flag", "z", "Zoner status will automatically be granted to players with this flag. If the convar is invalid or not set, z (root) will be used by default.", FCVAR_NOTIFY);
+	g_hZonerFlag = AutoExecConfig_CreateConVar("ck_zoner_flag", "z", "Zoner status will automatically be granted to players with this flag. If the convar is invalid or not set, z (root) will be used by default.", _);
 	GetConVarString(g_hZonerFlag, szFlag, 24);
 	validFlag = FindFlagByChar(szFlag[0], bufferFlag);
 	if (!validFlag)
@@ -293,10 +293,10 @@ void CreateConVars()
 	HookConVarChange(g_hZonerFlag, OnSettingChanged);
 
 	// Map Setting ConVars
-	g_hGravityFix = AutoExecConfig_CreateConVar("ck_gravityfix_enable", "1", "Enables/Disables trigger_gravity fix", FCVAR_NOTIFY, true, 0.0, true, 1.0);
+	g_hGravityFix = AutoExecConfig_CreateConVar("ck_gravityfix_enable", "1", "Enables/Disables trigger_gravity fix", _, true, 0.0, true, 1.0);
 
 	// VIP ConVars
-	g_hAutoVipFlag = AutoExecConfig_CreateConVar("ck_vip_flag", "a", "VIP status will be automatically granted to players with this flag. If the convar is invalid or not set, a (reservation) will be used by default.", FCVAR_NOTIFY);
+	g_hAutoVipFlag = AutoExecConfig_CreateConVar("ck_vip_flag", "a", "VIP status will be automatically granted to players with this flag. If the convar is invalid or not set, a (reservation) will be used by default.", _);
 	GetConVarString(g_hAutoVipFlag, szFlag, 24);
 	validFlag = FindFlagByChar(szFlag[0], bufferFlag);
 	if (!validFlag)


### PR DESCRIPTION
Excessive FCVAR_NOTIFY in convars.sp is causing a timeout issue in SM 1.11.

[NET] Cannot send 5171-byte packet to 208.113.198.125:54479. MTU is 1200

I have tested and indeed this fixes the issue. I don't think you would have this problem with SM 1.10 and A2S ruleshax as it patches the limit to 65000, SM 1.11 by default is 5000 now.

I would like to add, that I'm not a dev, things are probs wrong here but I made sure it compiles with no warnings or errors.