### PR TITLE
Add pre to all replay recordings 

### DIFF
--- a/addons/sourcemod/scripting/SurfTimer.sp
+++ b/addons/sourcemod/scripting/SurfTimer.sp
@@ -960,6 +960,10 @@ int g_iReplayTicksCount[MAXPLAYERS + 1];
 // Replay bot's current frame
 int g_iReplayTick[MAXPLAYERS + 1];
 
+// Add pre to replays
+int g_iStageStartTouchTick[MAXPLAYERS + 1];
+int g_iStartPressTick[MAXPLAYERS + 1]; 
+
 // Stage replays stuff
 int g_iStageStartFrame[MAXPLAYERS+1];
 bool g_bSavingWrcpReplay[MAXPLAYERS + 1];

--- a/addons/sourcemod/scripting/surftimer/buttonpress.sp
+++ b/addons/sourcemod/scripting/surftimer/buttonpress.sp
@@ -155,17 +155,29 @@ public void CL_OnStartTimerPress(int client)
 	// Play Start Sound
 	PlayButtonSound(client);
 
-	// Start recording for record bot
-	if ((!IsFakeClient(client) && GetConVarBool(g_hReplayBot)) || (!IsFakeClient(client) && GetConVarBool(g_hBonusBot)))
+	// Add pre
+	// // Start recording for record bot
+	// if ((!IsFakeClient(client) && GetConVarBool(g_hReplayBot)) || (!IsFakeClient(client) && GetConVarBool(g_hBonusBot)))
+	// {
+	// 	if (IsPlayerAlive(client))
+	// 	{
+	// 		StartRecording(client);
+	// 		if (g_bhasStages)
+	// 		{
+	// 			Stage_StartRecording(client);
+	// 		}
+	// 	}
+	// }
+
+	if (g_iRecordedTicks[client] == 0)
 	{
-		if (IsPlayerAlive(client))
-		{
-			StartRecording(client);
-			if (g_bhasStages)
-			{
-				Stage_StartRecording(client);
-			}
-		}
+		g_iStartPressTick[client] = g_iRecordedTicks[client];
+		CPrintToChat(client, "{gold}[REC] {green}StartTimerPress | g_iStartPressTick = {red}0");
+	} 
+	else if (g_iRecordedTicks[client] >= 128)
+	{
+		g_iStartPressTick[client] = g_iRecordedTicks[client] - 128;		
+		CPrintToChat(client, "{gold}[REC] {green}StartTimerPress | {darkred}Y U AFK{orchid}?{blue}!{green}? {orange}Recorded ticks: {red}%i{orange} | You left at: {red}%i", g_iRecordedTicks[client], g_iStartPressTick[client]);
 	}
 }
 
@@ -769,7 +781,7 @@ public void CL_OnStartWrcpTimerPress(int client)
 			// Enable Trigger Output on Timer Restart
 			g_bTeleByCommand[client] = false;
 			g_WrcpStage[client] = g_Stage[0][client];
-			Stage_StartRecording(client);
+			Stage_StartRecording(client); //Add pre
 		}
 		if (g_Stage[0][client] > 1 && !g_bPracticeMode[client] && !IsFakeClient(client)) {
 			char szDifference[128], szSpeed[128], preMessage[128];

--- a/addons/sourcemod/scripting/surftimer/buttonpress.sp
+++ b/addons/sourcemod/scripting/surftimer/buttonpress.sp
@@ -170,15 +170,13 @@ public void CL_OnStartTimerPress(int client)
 	// }
 
 	if (g_iRecordedTicks[client] == 0)
-	{
 		g_iStartPressTick[client] = g_iRecordedTicks[client];
-		CPrintToChat(client, "{gold}[REC] {green}StartTimerPress | g_iStartPressTick = {red}0");
-	} 
-	else if (g_iRecordedTicks[client] >= 128)
-	{
-		g_iStartPressTick[client] = g_iRecordedTicks[client] - 128;		
-		CPrintToChat(client, "{gold}[REC] {green}StartTimerPress | {darkred}Y U AFK{orchid}?{blue}!{green}? {orange}Recorded ticks: {red}%i{orange} | You left at: {red}%i", g_iRecordedTicks[client], g_iStartPressTick[client]);
-	}
+	else if (g_iRecordedTicks[client] >= (g_iTickrate * GetConVarInt(g_hReplayPre)))
+		g_iStartPressTick[client] = g_iRecordedTicks[client] - (g_iTickrate * GetConVarInt(g_hReplayPre));
+	else if (g_iRecordedTicks[client] >= g_iTickrate)
+		g_iStartPressTick[client] = g_iRecordedTicks[client] - g_iTickrate;
+			
+
 }
 
 // End Timer

--- a/addons/sourcemod/scripting/surftimer/commands.sp
+++ b/addons/sourcemod/scripting/surftimer/commands.sp
@@ -185,6 +185,8 @@ void CreateCommands()
 	RegConsoleCmd("sm_cpr", Command_CPR, "[surftimer] Compare clients time to another clients time");
 	RegConsoleCmd("sm_prinfo", Command_PRinfo, "[surftimer] Information about personal info on a map");
 	
+	// Add pre
+	RegConsoleCmd("sm_recordedticks", Command_RecordedTicks, "[surftimer] Current recorded ticks for client");
 
 	// reload map
 	RegAdminCmd("sm_rm", Command_ReloadMap, ADMFLAG_ROOT, "[surftimer] Reloads the current map");

--- a/addons/sourcemod/scripting/surftimer/commands.sp
+++ b/addons/sourcemod/scripting/surftimer/commands.sp
@@ -184,9 +184,6 @@ void CreateCommands()
 	// CPR
 	RegConsoleCmd("sm_cpr", Command_CPR, "[surftimer] Compare clients time to another clients time");
 	RegConsoleCmd("sm_prinfo", Command_PRinfo, "[surftimer] Information about personal info on a map");
-	
-	// Add pre
-	RegConsoleCmd("sm_recordedticks", Command_RecordedTicks, "[surftimer] Current recorded ticks for client");
 
 	// reload map
 	RegAdminCmd("sm_rm", Command_ReloadMap, ADMFLAG_ROOT, "[surftimer] Reloads the current map");

--- a/addons/sourcemod/scripting/surftimer/convars.sp
+++ b/addons/sourcemod/scripting/surftimer/convars.sp
@@ -31,6 +31,7 @@ ConVar g_hArmModel = null;										// Player arm models
 ConVar g_hcvarRestore = null;									// Restore player's runs?
 ConVar g_hNoClipS = null;										// Allow noclip?
 ConVar g_hReplayBot = null;										// Replay bot?
+ConVar g_hReplayPre = null;										// Seconds for prestrafe recording
 ConVar g_hWrcpBot = null;
 ConVar g_hBackupReplays = null;									// Back up replay bots?
 ConVar g_hReplaceReplayTime = null;								// Replace replay times, even if not SR
@@ -162,6 +163,7 @@ void CreateConVars()
 	g_iHintsInterval = AutoExecConfig_CreateConVar("ck_hints_interval", "240", "Seconds between two hints. Leave empty or set to 0 to disable", _, true, 0.0);
 	g_bHintsRandomOrder = AutoExecConfig_CreateConVar("ck_hints_random_order", "1", "(1 / 0) Enable/Disable hints shown in a random order", _, true, 0.0, true, 1.0);
 	g_hOverrideClantag = AutoExecConfig_CreateConVar("ck_override_clantag", "1", "Override player's clantag", _, true, 0.0, true, 1.0);
+	g_hReplayPre = AutoExecConfig_CreateConVar("ck_replay_pre", "1", "Maximum amount of seconds for prestrafe recording", _, true, 1.0);
 
 	g_hPointSystem = AutoExecConfig_CreateConVar("ck_point_system", "1", "on/off - Player point system", _, true, 0.0, true, 1.0);
 	HookConVarChange(g_hPointSystem, OnSettingChanged);

--- a/addons/sourcemod/scripting/surftimer/hooks.sp
+++ b/addons/sourcemod/scripting/surftimer/hooks.sp
@@ -181,8 +181,13 @@ public Action Event_OnPlayerSpawn(Handle event, const char[] name, bool dontBroa
 				g_bIgnoreZone[client] = false;
 			}
 
+			//1st spawn start recording
+			StartRecording(client); //Add pre
+			if (g_bhasStages){
+				// CPrintToChat(client, "{gold}[REC] FIRST SPAWN | {green}Started {blue}Stage{green} recording");
+				Stage_StartRecording(client); //Add pre
+			}
 
-			StartRecording(client);
 			CreateTimer(1.5, CenterMsgTimer, client, TIMER_FLAG_NO_MAPCHANGE);
 
 			//THIS "FIXES" A BUG WHERE THE TIMEINCREMENT WOULD BE CHANGED IN THE BEGINNING FOR FUCK ALL REASON...

--- a/addons/sourcemod/scripting/surftimer/hooks.sp
+++ b/addons/sourcemod/scripting/surftimer/hooks.sp
@@ -183,10 +183,8 @@ public Action Event_OnPlayerSpawn(Handle event, const char[] name, bool dontBroa
 
 			//1st spawn start recording
 			StartRecording(client); //Add pre
-			if (g_bhasStages){
-				// CPrintToChat(client, "{gold}[REC] FIRST SPAWN | {green}Started {blue}Stage{green} recording");
+			if (g_bhasStages)
 				Stage_StartRecording(client); //Add pre
-			}
 
 			CreateTimer(1.5, CenterMsgTimer, client, TIMER_FLAG_NO_MAPCHANGE);
 

--- a/addons/sourcemod/scripting/surftimer/replay.sp
+++ b/addons/sourcemod/scripting/surftimer/replay.sp
@@ -116,7 +116,15 @@ public void StartRecording(int client)
 		return;
 	}
 
-	g_iRecordedTicks[client] = 0;
+	//Add pre
+	if (g_bNewReplay[client] || g_bNewBonus[client]) // Don't allow starting the timer, if players record is being saved
+		return;
+	else
+	{
+		g_iRecordedTicks[client] = 0;
+		delete g_aRecording[client]; //Add pre
+		g_aRecording[client] = new ArrayList(sizeof(frame_t)); //Add pre
+	}
 }
 
 public void StopRecording(int client)
@@ -177,15 +185,40 @@ public void SaveRecording(int client, int zgroup, int style)
 	char szName[MAX_NAME_LENGTH];
 	GetClientName(client, szName, MAX_NAME_LENGTH);
 
+	//Add pre
+	int startFrame = g_iStartPressTick[client];
+	int endFrame = g_iRecordedTicks[client];
+
 	FileHeader header;
 	header.BinaryFormatVersion = BINARY_FORMAT_VERSION;
 	strcopy(header.Time, sizeof(FileHeader::Time), g_szFinalTime[client]);
-	header.TickCount = g_iRecordedTicks[client];
+	// header.TickCount = g_iRecordedTicks[client]; //Add pre
+	header.TickCount = endFrame - startFrame; //Add pre
 	strcopy(header.Playername, sizeof(FileHeader::Playername), szName);
 	header.Checkpoints = 0;
-	header.Frames = g_aRecording[client];
+	// header.Frames = g_aRecording[client]; //Add pre
+
+	// Copy pasta stage separation method for proper Map/Bonus start frame
+	header.Frames = new ArrayList(sizeof(frame_t));
+	any aFrameData[sizeof(frame_t)];
+
+	for (int i = startFrame; i < endFrame; i++)
+	{
+		if (i == -1)
+		{
+			LogError("Map record cannot be saved. Client: \"%L\", startFrame: %d, endFrame: %d (g_iRecordedTicks: %d), i: %d, Path/File: %s", client, startFrame, endFrame, g_iRecordedTicks[client], i, sPath2);
+			continue;
+		}
+		
+		g_aRecording[client].GetArray(i, aFrameData, sizeof(frame_t));
+		header.Frames.PushArray(aFrameData, sizeof(frame_t));
+	}
+
+	// CPrintToChat(client, "{gold}[REC] SaveRecording | {blue}header.TickCount = {red}%i {blue}header.Frames = {red}%i {blue}startFrame = {red}%i", endFrame - startFrame, GetArraySize(g_aRecording[client]), startFrame);
 
 	WriteRecordToDisk(sPath2, header);
+
+	delete header.Frames;
 
 	g_bNewReplay[client] = false;
 	g_bNewBonus[client] = false;
@@ -201,6 +234,12 @@ static void ClearFrame(int client)
 	delete g_aRecording[client];
 	g_aRecording[client] = new ArrayList(sizeof(frame_t));
 	g_iRecordedTicks[client] = 0;
+}
+
+public Action Command_RecordedTicks(int client, int args)
+{
+	CPrintToChat(client, "{gold}[REC] {green}g_iRecordedTicks = {red}%i", g_iRecordedTicks[client]);
+	CPrintToChat(client, "{gold}[REC] {green}g_aRecording = {red}%i", GetArraySize(g_aRecording[client]));
 }
 
 public void LoadReplays()
@@ -1349,14 +1388,38 @@ public void Stage_StartRecording(int client)
 		return;
 	}
 
-	g_iStageStartFrame[client] = g_iRecordedTicks[client];
-
 	char szName[MAX_NAME_LENGTH];
 	GetClientName(client, szName, MAX_NAME_LENGTH);
 
-	if (g_aRecording[client] == null)
+	// Add pre
+	// if (g_aRecording[client] == null)
+	// {
+	// 	StartRecording(client);
+	// }
+
+	// Set the stage recording start frame to up to 1 second before leaving the zone
+	// Also prevent the start frame being from the previous stage
+	if (g_iRecordedTicks[client] == 0)
 	{
-		StartRecording(client);
+		g_iStageStartFrame[client] = g_iRecordedTicks[client];
+	} 
+	else if (g_iRecordedTicks[client] >= 128)
+	{
+		// CPrintToChat(client, "{gold}[REC] {green}Stage_StartRecording | g_iStageStartFrame {red}(%i){green} => {red}128", g_iStageStartFrame[client]);
+		g_iStageStartFrame[client] = g_iRecordedTicks[client] - 128;
+		if (g_iStageStartTouchTick[client] > g_iStageStartFrame[client]) g_iStageStartFrame[client] = g_iStageStartTouchTick[client];
+	}
+	else if (g_iRecordedTicks[client] >= 64)
+	{
+		// CPrintToChat(client, "{gold}[REC] {green}Stage_StartRecording | g_iStageStartFrame {red}(%i){green} => {red}64", g_iStageStartFrame[client]);
+		g_iStageStartFrame[client] = g_iRecordedTicks[client] - 64;
+		if (g_iStageStartTouchTick[client] > g_iStageStartFrame[client]) g_iStageStartFrame[client] = g_iStageStartTouchTick[client];
+	}
+	else if (g_iRecordedTicks[client] >= 32)
+	{
+		// CPrintToChat(client, "{gold}[REC] {green}Stage_StartRecording | g_iStageStartFrame {red}(%i){green} => {red}32", g_iStageStartFrame[client]);
+		g_iStageStartFrame[client] = g_iRecordedTicks[client] - 32;
+		if (g_iStageStartTouchTick[client] > g_iStageStartFrame[client]) g_iStageStartFrame[client] = g_iStageStartTouchTick[client];
 	}
 }
 
@@ -1412,6 +1475,9 @@ public void Stage_SaveRecording(int client, int stage, char[] time)
 		g_aRecording[client].GetArray(i, aFrameData, sizeof(frame_t));
 		header.Frames.PushArray(aFrameData, sizeof(frame_t));
 	}
+
+	// CPrintToChat(client, "{gold}[REC] Stage_SaveRecording | {blue}header.TickCount = {red}%i", g_iRecordedTicks[client]);
+	// CPrintToChat(client, "{gold}Stage record saved. startFrame: %d (g_iStageStartFrame: %d), endFrame: %d (g_iRecordedTicks: %d)", startFrame, g_iStageStartFrame[client], endFrame, g_iRecordedTicks[client]);
 
 	WriteRecordToDisk(sPath2, header);
 

--- a/addons/sourcemod/scripting/surftimer/surfzones.sp
+++ b/addons/sourcemod/scripting/surftimer/surfzones.sp
@@ -396,6 +396,9 @@ public void StartTouch(int client, int action[3])
 			lastCheckpoint[g_iClientInZone[client][2]][client] = 1;
 			g_bSaveLocTele[client] = false;
 
+			// StopRecording(client); //Add pre
+			StartRecording(client); //Add pre
+
 			if (g_bPracticeMode[client])
 			{
 				g_bPracticeMode[client] = false;
@@ -407,6 +410,8 @@ public void StartTouch(int client, int action[3])
 				g_bWrcpTimeractivated[client] = false;
 				g_bPracSrcpTimerActivated[client] = false;
 				g_CurrentStage[client] = 0;
+				// Prevents the Stage(X) replay from starting before the Stage(X) start zone
+				g_iStageStartTouchTick[client] = g_iRecordedTicks[client]; //Add pre
 			}
 		}
 		else if (action[0] == 2) // End Zone
@@ -475,6 +480,8 @@ public void StartTouch(int client, int action[3])
 			g_bInDuck[client] = false;
 			g_KeyCount[client] = 0;
 
+			// Prevents the Stage(X) replay from starting before the Stage(X) start zone
+			g_iStageStartTouchTick[client] = g_iRecordedTicks[client]; //Add pre
 			// stop bot wrcp timer
 			if (client == g_WrcpBot)
 			{


### PR DESCRIPTION
- This PR adds up to **X** amount of seconds prestrafe for all new replays that are recorded (Maps, Bonuses, Stages)
- Convar created to control the amount per server
- Prevents replays to contain lots of unnecessary data (people sitting AFK in any start zone)
- Prevents stage replays to start from end of previous stages

Does **NOT** break any already existing replays to **MY** knowledge - more testing needed on this part

Not all debug messages have been turned off, nor has been the command which I added in order to check ticks while in-game.
If anyone wants to test on a live server lmk to remove them :)

Here are some replay files produced using this same fork: [replays-with-pre.gz](https://github.com/surftimer/SurfTimer/files/8880024/replays-with-pre.gz)

might as well tag myself #387 