### PR TITLE
Fix Player Titles

### DIFF
--- a/addons/sourcemod/scripting/surftimer/sql.sp
+++ b/addons/sourcemod/scripting/surftimer/sql.sp
@@ -9437,6 +9437,8 @@ public void SQL_checkCustomPlayerTitleCallback(Handle owner, Handle hndl, const 
 	if (SQL_HasResultSet(hndl) && SQL_FetchRow(hndl))
 	{
 		db_updateCustomPlayerTitle(client, szSteamID, arg);
+	} else {
+		db_insertCustomPlayerTitle(client, szSteamID, arg);
 	}
 }
 


### PR DESCRIPTION
A [recent commit](https://github.com/surftimer/SurfTimer/commit/a7768e1ba4e64faa624cfe5a711ae8ceb4b682fb#r75944129) prevented players from setting a custom title if their custom title wasn't already enabled. This PR re-adds the insert statement if the database does not have any rows matching a Steam ID.