### PR TITLE
dont reload ck_chat_record_type

### DIFF
--- a/addons/sourcemod/scripting/surftimer/mapsettings.sp
+++ b/addons/sourcemod/scripting/surftimer/mapsettings.sp
@@ -1,7 +1,6 @@
 public void setMapSettings()
 {
 	SetConVarFloat(g_hMaxVelocity, g_fMaxVelocity, true, true);
-	SetConVarFloat(g_hAnnounceRecord, g_fAnnounceRecord, true, true);
 	SetConVarBool(g_hGravityFix, g_bGravityFix, true, true);
 }
 


### PR DESCRIPTION
Currently `ck_chat_record_type` goes back to `0` which is default value set in code if the map reloads `mp_restartgame` 