### PR TITLE
add fRunTime to WRCP forward

### DIFF
--- a/addons/sourcemod/scripting/include/surftimer.inc
+++ b/addons/sourcemod/scripting/include/surftimer.inc
@@ -194,9 +194,10 @@ forward void surftimer_OnNewRecord(int client, int style, char[] time, char[] ti
  * @param style				Style index.
  * @param time				Time set by the player.
  * @param timeDif			Time difference with the former record.
- * @param stage			  The id of the stage of the WRCP.
+ * @param stage			  	The id of the stage of the WRCP.
+ * @param fRunTime			Run time for the WRCP in float.
  */
-forward void surftimer_OnNewWRCP(int client, int style, char[] time, char[] timeDif, int stage);
+forward void surftimer_OnNewWRCP(int client, int style, char[] time, char[] timeDif, int stage, float fRunTime);
 
 public SharedPlugin:__pl_surftimer =
 {

--- a/addons/sourcemod/scripting/surftimer/api.sp
+++ b/addons/sourcemod/scripting/surftimer/api.sp
@@ -228,7 +228,7 @@ void Register_Forwards()
 	g_BonusFinishForward = new GlobalForward("surftimer_OnBonusFinished", ET_Event, Param_Cell, Param_Float, Param_String, Param_Cell, Param_Cell, Param_Cell);
 	g_PracticeFinishForward = new GlobalForward("surftimer_OnPracticeFinished", ET_Event, Param_Cell, Param_Float, Param_String);
 	g_NewRecordForward = new GlobalForward("surftimer_OnNewRecord", ET_Event, Param_Cell, Param_Cell, Param_String, Param_String, Param_Cell);
-	g_NewWRCPForward = new GlobalForward("surftimer_OnNewWRCP", ET_Event, Param_Cell, Param_Cell, Param_String, Param_String, Param_Cell);
+	g_NewWRCPForward = new GlobalForward("surftimer_OnNewWRCP", ET_Event, Param_Cell, Param_Cell, Param_String, Param_String, Param_Cell, Param_Float);
 }
 
 /**
@@ -362,8 +362,9 @@ void SendNewRecordForward(int client, const char[] szRecordDiff, int bonusGroup 
  * @param client           Index of the client.
  * @param stage            ID of the stage.
  * @param szRecordDiff     String containing the formatted difference with the previous record.
+ * @param fRunTime		   Float value for the record time
  */
-void SendNewWRCPForward(int client, int stage, const char[] szRecordDiff)
+void SendNewWRCPForward(int client, int stage, const char[] szRecordDiff, float fRunTime)
 {
 	/* Start New record function call */
 	Call_StartForward(g_NewWRCPForward);
@@ -374,6 +375,7 @@ void SendNewWRCPForward(int client, int stage, const char[] szRecordDiff)
 	Call_PushString(g_szFinalWrcpTime[client]);
 	Call_PushString(szRecordDiff);
 	Call_PushCell(stage);
+	Call_PushFloat(fRunTime);
 
 	/* Finish the call, get the result */
 	Call_Finish();

--- a/addons/sourcemod/scripting/surftimer/sql.sp
+++ b/addons/sourcemod/scripting/surftimer/sql.sp
@@ -6716,7 +6716,7 @@ public void SQL_UpdateWrcpRecordCallback2(Handle owner, Handle hndl, const char[
 				g_bSavingWrcpReplay[client] = true;
 				// Stage_SaveRecording(client, stage, g_szFinalWrcpTime[client]);
 				PlayWRCPRecord();
-				SendNewWRCPForward(client, stage, sz_srRawDiff);
+				SendNewWRCPForward(client, stage, sz_srRawDiff, g_fStageRecord[stage]);
 
 				SetNewRecordPrestrafe(client, stage, 0, false, false, true);
 			}
@@ -6742,7 +6742,7 @@ public void SQL_UpdateWrcpRecordCallback2(Handle owner, Handle hndl, const char[
 			g_bSavingWrcpReplay[client] = true;
 			// Stage_SaveRecording(client, stage, g_szFinalWrcpTime[client]);
 			PlayWRCPRecord();
-			SendNewWRCPForward(client, stage, sz_srRawDiff);
+			SendNewWRCPForward(client, stage, sz_srRawDiff, g_fStageRecord[stage]);
 
 			SetNewRecordPrestrafe(client, stage, 0, false, false, true);
 		}
@@ -6765,7 +6765,7 @@ public void SQL_UpdateWrcpRecordCallback2(Handle owner, Handle hndl, const char[
 
 				CPrintToChatAll("%t", "SQL19", g_szChatPrefix, szName, g_szStyleRecordPrint[style], stage, g_szFinalWrcpTime[client], sz_srDiff, g_StyleStageRank[style][client][stage], g_TotalStageStyleRecords[style][stage]);
 				PlayWRCPRecord();
-				SendNewWRCPForward(client, stage, sz_srRawDiff);
+				SendNewWRCPForward(client, stage, sz_srRawDiff, g_fStageRecord[stage]);
 
 				SetNewRecordPrestrafe(client, stage, style, false, false, true);
 			}
@@ -6789,7 +6789,7 @@ public void SQL_UpdateWrcpRecordCallback2(Handle owner, Handle hndl, const char[
 
 			CPrintToChatAll("%t", "SQL22", g_szChatPrefix, szName, g_szStyleRecordPrint[style], stage, g_szFinalWrcpTime[client]);
 			PlayWRCPRecord();
-			SendNewWRCPForward(client, stage, sz_srRawDiff);
+			SendNewWRCPForward(client, stage, sz_srRawDiff, g_fStageRecord[stage]);
 
 			SetNewRecordPrestrafe(client, stage, style, false, false, true);
 		}


### PR DESCRIPTION
Current output of the forward _(excluding client)_
```
Style: 7 ; Time: 00:02:32 ; Diff: -00:00:77 ; Stage: 1 ; Float Time: 1.992200
```

Also tested this with `SurfTimer-Discord 2.1.3` turned on (without any edits to it) and it works fine announcing the record in Discord:
![image](https://user-images.githubusercontent.com/74899888/183417264-4413a63b-a96b-4a3c-b3d7-8f80aa128047.png)
