### PR TITLE
Fix Replays with CP selected

### DIFF
--- a/addons/sourcemod/scripting/surftimer/commands.sp
+++ b/addons/sourcemod/scripting/surftimer/commands.sp
@@ -6444,12 +6444,14 @@ public void PlayRecordCPMenu(int client, char szBuffer[128])
 				AddMenuItem(menu_replay_cp, szBuffer_menu, szItem);
 			}
 			else{
-				if(!g_bhasStages)
-					Format(szItem, sizeof(szItem), "Checkpoint %d ", i);
-				else
-					Format(szItem, sizeof(szItem), "Stage %d ", i + 1);
-				Format(szBuffer_menu, sizeof(szBuffer_menu), "checkpoint-%d", i);
-				AddMenuItem(menu_replay_cp, szBuffer_menu, szItem);
+				if (g_bReplayTickFound[0]) {
+					if(!g_bhasStages)
+						Format(szItem, sizeof(szItem), "Checkpoint %d ", i);
+					else
+						Format(szItem, sizeof(szItem), "Stage %d ", i + 1);
+					Format(szBuffer_menu, sizeof(szBuffer_menu), "checkpoint-%d", i);
+					AddMenuItem(menu_replay_cp, szBuffer_menu, szItem);
+				}
 			}
 		}
 	else{
@@ -6468,12 +6470,14 @@ public void PlayRecordCPMenu(int client, char szBuffer[128])
 					AddMenuItem(menu_replay_cp, szBuffer_menu, szItem);
 				}
 				else{
-					if(!g_bhasStages)
-						Format(szItem, sizeof(szItem), "%s | Checkpoint %d ", g_szStyleMenuPrint[style], i);
-					else
-						Format(szItem, sizeof(szItem), "%s | Stage %d ", g_szStyleMenuPrint[style], i + 1);
-					Format(szBuffer_menu, sizeof(szBuffer_menu), "style-%i-checkpoint-%d", style, i);
-					AddMenuItem(menu_replay_cp, szBuffer_menu, szItem);
+					if (g_bReplayTickFound[g_iSelectedReplayStyle]){
+						if(!g_bhasStages)
+							Format(szItem, sizeof(szItem), "%s | Checkpoint %d ", g_szStyleMenuPrint[style], i);
+						else
+							Format(szItem, sizeof(szItem), "%s | Stage %d ", g_szStyleMenuPrint[style], i + 1);
+						Format(szBuffer_menu, sizeof(szBuffer_menu), "style-%i-checkpoint-%d", style, i);
+						AddMenuItem(menu_replay_cp, szBuffer_menu, szItem);
+					}
 				}
 			}
 

--- a/addons/sourcemod/scripting/surftimer/db/queries.sp
+++ b/addons/sourcemod/scripting/surftimer/db/queries.sp
@@ -133,6 +133,6 @@ char sql_clearPRruntime[] = "UPDATE ck_prinfo SET runtime = '0.0' WHERE steamid 
 char sql_createReplays[] = "CREATE TABLE IF NOT EXISTS ck_replays (mapname VARCHAR(32), cp int(12) NOT NULL DEFAULT '0', frame int(12) NOT NULL DEFAULT '0', style INT(12) NOT NULL DEFAULT '0', PRIMARY KEY(mapname, cp, style)) DEFAULT CHARSET=utf8mb4;";
 char sql_selectReplayCPTicksAll[] = "SELECT cp, frame, style FROM ck_replays WHERE mapname = '%s' AND style = '%i' ORDER BY cp ASC;";
 char sql_insertReplayCPTicks[] = "INSERT INTO ck_replays (mapname, cp, frame, style) VALUES ('%s', '%i', '%i', '%i')";
-char sql_updateReplayCPTicks[] = "UPDATE ck_replays frame='%i' WHERE mapname='%s' AND cp ='%i' AND style='%i';";
+char sql_updateReplayCPTicks[] = "UPDATE ck_replays SET frame='%i' WHERE mapname='%s' AND cp ='%i' AND style='%i';";
 //check tables data type
 char sql_checkDataType[] = "SELECT DATA_TYPE, NUMERIC_PRECISION, NUMERIC_SCALE FROM information_schema.COLUMNS WHERE TABLE_SCHEMA='%s' AND TABLE_NAME='%s' AND COLUMN_NAME='%s' HAVING DATA_TYPE = 'decimal' AND NUMERIC_PRECISION = 12 AND NUMERIC_SCALE = 6;";

--- a/addons/sourcemod/scripting/surftimer/db/queries.sp
+++ b/addons/sourcemod/scripting/surftimer/db/queries.sp
@@ -133,7 +133,6 @@ char sql_clearPRruntime[] = "UPDATE ck_prinfo SET runtime = '0.0' WHERE steamid 
 char sql_createReplays[] = "CREATE TABLE IF NOT EXISTS ck_replays (mapname VARCHAR(32), cp int(12) NOT NULL DEFAULT '0', frame int(12) NOT NULL DEFAULT '0', style INT(12) NOT NULL DEFAULT '0', PRIMARY KEY(mapname, cp, style)) DEFAULT CHARSET=utf8mb4;";
 char sql_selectReplayCPTicksAll[] = "SELECT cp, frame, style FROM ck_replays WHERE mapname = '%s' AND style = '%i' ORDER BY cp ASC;";
 char sql_insertReplayCPTicks[] = "INSERT INTO ck_replays (mapname, cp, frame, style) VALUES ('%s', '%i', '%i', '%i')";
-char sql_updateReplayCPTicks[] = "UPDATE ck_replays SET cp='%i', frame='%i' WHERE mapname='%s' AND style='%i';";
-
+char sql_updateReplayCPTicks[] = "UPDATE ck_replays frame='%i' WHERE mapname='%s' AND cp ='%i' AND style='%i';";
 //check tables data type
 char sql_checkDataType[] = "SELECT DATA_TYPE, NUMERIC_PRECISION, NUMERIC_SCALE FROM information_schema.COLUMNS WHERE TABLE_SCHEMA='%s' AND TABLE_NAME='%s' AND COLUMN_NAME='%s' HAVING DATA_TYPE = 'decimal' AND NUMERIC_PRECISION = 12 AND NUMERIC_SCALE = 6;";

--- a/addons/sourcemod/scripting/surftimer/replay.sp
+++ b/addons/sourcemod/scripting/surftimer/replay.sp
@@ -147,14 +147,6 @@ public void SaveRecording(int client, int zgroup, int style)
 	g_bNewReplay[client] = false;
 	g_bNewBonus[client] = false;
 
-	for(int i = 0; i < MAX_STYLES; i++)
-	{
-		for(int j = 0; j < CPLIMIT; j++)
-		{
-			g_iCPStartFrame[i][j] = g_iCPStartFrame_CurrentRun[i][j][client];
-		}
-	}
-
 	// Check if the default record folder exists
 	char sPath2[256];
 	BuildPath(Path_SM, sPath2, sizeof(sPath2), "%s", CK_REPLAY_PATH);
@@ -232,7 +224,15 @@ public void SaveRecording(int client, int zgroup, int style)
 		StopRecording(client);
 	}
 
-	db_UpdateReplaysTick(client, style);
+	if(zgroup == 0) {
+
+		for(int j = 0; j < CPLIMIT; j++)
+		{
+			g_iCPStartFrame[style][j] = g_iCPStartFrame_CurrentRun[style][j][client];
+		}
+
+		db_UpdateReplaysTick(client, style);
+	}
 }
 
 static void ClearFrame(int client)
@@ -563,7 +563,7 @@ public void PlayRecord(int client, int type, int style, int use_CP)
 	g_iReplayVersion[client] = header.BinaryFormatVersion;
 
 	if(use_CP > 0)
-		g_iReplayTick[client] = g_iCPStartFrame[style][use_CP];
+		g_iReplayTick[client] = g_iCPStartFrame[style][use_CP-1];
 	else
 		g_iReplayTick[client] = 0;
 

--- a/addons/sourcemod/scripting/surftimer/sql.sp
+++ b/addons/sourcemod/scripting/surftimer/sql.sp
@@ -3443,7 +3443,8 @@ public void db_UpdateReplaysTick(int client, int style){
 		}
 	}
 
-	SQL_ExecuteTransaction(g_hDb, TicksTransaction, db_TicksTransactionOnSuccess, db_TicksTransactionOnFailure, DBPrio_Low);
+	SQL_ExecuteTransaction(g_hDb, TicksTransaction, db_TicksTransactionOnSuccess, db_TicksTransactionOnFailure, _, DBPrio_Low);
+
 }
 
 public void db_TicksTransactionOnSuccess(Handle db, any pack, int numQueries, Handle[] results, any[] queryData)

--- a/addons/sourcemod/scripting/surftimer/sql.sp
+++ b/addons/sourcemod/scripting/surftimer/sql.sp
@@ -3396,7 +3396,7 @@ public void SQL_selectReplayCPTicksCallback(Handle owner, Handle hndl, const cha
 			frame = SQL_FetchInt(hndl, 1);
 			style = SQL_FetchInt(hndl, 2);
 
-			g_iCPStartFrame[style][cp] = frame;
+			g_iCPStartFrame[style][cp-1] = frame;
 
 			if (!g_bReplayTickFound[style] && g_iCPStartFrame[style][cp - 1] > 0)
 				g_bReplayTickFound[style] = true;

--- a/addons/sourcemod/scripting/surftimer/sql.sp
+++ b/addons/sourcemod/scripting/surftimer/sql.sp
@@ -3427,28 +3427,33 @@ public void db_UpdateReplaysTick(int client, int style){
 	else
 		cp_count = g_TotalStages - 1;
 
+	Transaction TicksTransaction = new Transaction();
+
 	if(!g_bReplayTickFound[style]){
 		g_bReplayTickFound[style] = true;
 		for(int i = 0; i < cp_count; i++){
 			Format(szQuery, sizeof(szQuery), sql_insertReplayCPTicks, g_szMapName, i+1, g_iCPStartFrame[style][i], style);
-			SQL_TQuery(g_hDb, SQL_UpdateReplaysTickCallback, szQuery, _, DBPrio_Low);
+			TicksTransaction.AddQuery(szQuery);
 		}
 	}
 	else{
 		for(int i = 0; i < cp_count; i++){
 			Format(szQuery, sizeof(szQuery), sql_updateReplayCPTicks, g_szMapName, i+1, g_iCPStartFrame[style][i], style);
-			SQL_TQuery(g_hDb, SQL_UpdateReplaysTickCallback, szQuery, _, DBPrio_Low);
+			TicksTransaction.AddQuery(szQuery);
 		}
 	}
+
+	SQL_ExecuteTransaction(g_hDb, TicksTransaction, db_TicksTransactionOnSuccess, db_TicksTransactionOnFailure, DBPrio_Low);
 }
 
-public void SQL_UpdateReplaysTickCallback(Handle owner, Handle hndl, const char[] error, any pack)
+public void db_TicksTransactionOnSuccess(Handle db, any pack, int numQueries, Handle[] results, any[] queryData)
 {
-	if (hndl == null)
-	{
-		LogError("[SurfTimer] SQL Error (SQL_UpdateReplaysTickCallback): %s", error);
-		return;
-	}
+	PrintToServer("[SurfTimer] Transaction Sucessfully Done!");
+}
+
+public void db_TicksTransactionOnFailure(Handle db, any pack, int numQueries, const char[] error, int failIndex, any[] queryData)
+{
+	LogError("[SurfTimer] SQL Error (db_TicksTransactionOnFailure): %s", error);
 }
 
 public void db_viewCheckpointsinZoneGroup(int client, char szSteamID[32], char szMapName[128], int zonegroup)

--- a/addons/sourcemod/scripting/surftimer/sql.sp
+++ b/addons/sourcemod/scripting/surftimer/sql.sp
@@ -3438,7 +3438,7 @@ public void db_UpdateReplaysTick(int client, int style){
 	}
 	else{
 		for(int i = 0; i < cp_count; i++){
-			Format(szQuery, sizeof(szQuery), sql_updateReplayCPTicks, g_szMapName, i+1, g_iCPStartFrame[style][i], style);
+			Format(szQuery, sizeof(szQuery), sql_updateReplayCPTicks, g_iCPStartFrame[style][i], g_szMapName, i+1, style);
 			TicksTransaction.AddQuery(szQuery);
 		}
 	}


### PR DESCRIPTION
error occuring before 
![image](https://user-images.githubusercontent.com/70631212/183781186-abf0dccc-4f66-4a20-93c9-8f3cf45f94ab.png)

was due to wrong query format resulting in a false positive regarding duplicate entry

added a check to not display the starting points from replay incase there was no replay cp ticks found when loading

also swapped multiple queries to a unique transaction instead