### PR TITLE
increase database name length

### DIFF
--- a/addons/sourcemod/scripting/surftimer/globals.sp
+++ b/addons/sourcemod/scripting/surftimer/globals.sp
@@ -1545,7 +1545,7 @@ char RadioCMDS[][] =  // Disable radio commands
 	"go_b", "sorry", "needrop", "playerradio", "playerchatwheel", "chatwheel_ping", "player_ping"
 };
 
-char g_sDatabaseName[32]; // Required for the float to decimal conversion
+char g_sDatabaseName[64]; // Required for the float to decimal conversion
 char g_sDecimalTables[][][] = {
 	// Table,              Column
 	{ "ck_bonus",         "runtime", },


### PR DESCRIPTION
if database name is greater than 32 then will get following error

[SM] Exception reported: More/Less then 1 rows? RowCount: 0, Table: ck_bonus, Column: runtime [SM] Blaming: SurfTimer.smx
[SM] Call stack trace:
[SM]   [0] SetFailState
[SM]   [1] Line 241, surftimer/db/updater.sp::SQLCheckDataType