### PR TITLE
Fix LoadDefaultTitle (only load the first one)

### DIFF
--- a/addons/sourcemod/scripting/surftimer/misc.sp
+++ b/addons/sourcemod/scripting/surftimer/misc.sp
@@ -4819,6 +4819,8 @@ public void LoadDefaultTitle(int client)
 						g_iEnforceTitleType[client] = 0;
 					else
 						g_iEnforceTitleType[client] = 2;
+					// If the title is enforced, break the loop
+					break;
 				}
 			} while (KvGotoNextKey(kv));
 		}

--- a/addons/sourcemod/scripting/surftimer/misc.sp
+++ b/addons/sourcemod/scripting/surftimer/misc.sp
@@ -4794,38 +4794,32 @@ public void LoadDefaultTitle(int client)
 						KvGetString(kv, "title", szBuffer, sizeof(szBuffer));
 						SetDefaultTitle(client, szBuffer);
 						g_iHasEnforcedTitle[client] = true;
-						break;
-					} else {
-						g_iHasEnforcedTitle[client] = false;
-						continue;
 					}
-
 				}
-
 				KvGetString(kv, "flag", szBuffer, sizeof(szBuffer), "none");
-				// Has to be a flag since no steamid was found, otherwise invalid entry
-				if (StrEqual(szBuffer, "none"))
-					continue;
-
-				// Check if client has access to this flag
-				int bit = ReadFlagString(szBuffer);
-				if (!CheckCommandAccess(client, "", bit))
-					continue;
-
-				// "type"
-				g_iEnforceTitleType[client] = 2;
-				KvGetString(kv, "type", szBuffer, sizeof(szBuffer), "both");
-				if (StrEqual(szBuffer, "scoreboard"))
-					g_iEnforceTitleType[client] = 1;
-				else if (StrEqual(szBuffer, "chat"))
-					g_iEnforceTitleType[client] = 0;
-				else
-					g_iEnforceTitleType[client] = 2;
-
-				KvGetString(kv, "title", szBuffer, sizeof(szBuffer));
-				SetDefaultTitle(client, szBuffer);
-				break;
-
+				// Check if this keyvalue has a flag
+				if (!StrEqual(szBuffer, "none"))
+				{
+					// Does the user has permissions over the flag?
+					int bit = ReadFlagString(szBuffer);
+					if (CheckCommandAccess(client, "", bit))
+					{
+						KvGetString(kv, "title", szBuffer, sizeof(szBuffer));
+						SetDefaultTitle(client, szBuffer);
+						g_iHasEnforcedTitle[client] = true;
+					}
+				}
+				// If user has enforced title, check and set the type
+				if (g_iHasEnforcedTitle[client] == true)
+				{
+					KvGetString(kv, "type", szBuffer, sizeof(szBuffer), "both");
+					if (StrEqual(szBuffer, "scoreboard"))
+						g_iEnforceTitleType[client] = 1;
+					else if (StrEqual(szBuffer, "chat"))
+						g_iEnforceTitleType[client] = 0;
+					else
+						g_iEnforceTitleType[client] = 2;
+				}
 			} while (KvGotoNextKey(kv));
 		}
 		delete kv;


### PR DESCRIPTION
Today i have been trying to configure my surf server.

I wanted to have my own SPONSOR title and another one for the users with z flag (Admin).

I only been able to load the first tag on the file. After doing a lot of debug, i could see that it wont loop over all the items so i made these changes to be able to load multiple default titles.