### PR TITLE
ck_prestige_rank fix

### DIFF
--- a/addons/sourcemod/scripting/surftimer/sql.sp
+++ b/addons/sourcemod/scripting/surftimer/sql.sp
@@ -1623,7 +1623,7 @@ public void sql_selectRankedPlayersRankCallback(Handle owner, Handle hndl, const
 				CS_SetClientContributionScore(client, -g_PlayerRank[client][style]);
 		}
 	}
-	else if (style == 0 && GetConVarInt(g_hPrestigeRank) >= 0 && !g_bPrestigeCheck[client])
+	else if (style == 0 && GetConVarInt(g_hPrestigeRank) > 0 && !g_bPrestigeCheck[client])
 		KickClient(client, "You must be at least rank %i to join this server", GetConVarInt(g_hPrestigeRank));
 
 	if (!g_bSettingsLoaded[client] && style == (MAX_STYLES - 1))


### PR DESCRIPTION
fix for sql_selectRankedPlayersRankCallback having no result (no rank) players would be kicked from the server if the convar was set to 0