### PR TITLE
CPR command update

### DIFF
--- a/addons/sourcemod/scripting/surftimer/commands.sp
+++ b/addons/sourcemod/scripting/surftimer/commands.sp
@@ -5967,8 +5967,7 @@ public Action Command_CPR(int client, int args)
 		}
 		else
 		{
-			CReplyToCommand(client, "%s{default}You {darkred}do not{default} have a personal best yet, use:", g_szChatPrefix);
-			CReplyToCommand(client, "%s{yellow}!cpr {green}@<rank> @<rank> {blue}<mapname> {default}(mapname is optional)", g_szChatPrefix);
+			CReplyToCommand(client, "%t", "Commands90", g_szChatPrefix);
 		}
 		return Plugin_Handled;
 	}

--- a/addons/sourcemod/scripting/surftimer/commands.sp
+++ b/addons/sourcemod/scripting/surftimer/commands.sp
@@ -5981,7 +5981,7 @@ public Action Command_CPR(int client, int args)
 	GetCmdArg(1, arg, sizeof(arg));
 	if (StrContains(arg, "@") != -1)
 	{
-		ReplaceString(arg, 128, "@", "");
+		ReplaceString(arg, sizeof(arg), "@", "");
 		rank1 = StringToInt(arg);
 	}
 	else if(arg[0]) // Look for in-game player with argument for comparing with -> rank1
@@ -6030,7 +6030,7 @@ public Action Command_CPR(int client, int args)
 	GetCmdArg(2, arg, sizeof(arg));
 	if (StrContains(arg, "@") != -1)
 	{
-		ReplaceString(arg, 128, "@", "");
+		ReplaceString(arg, sizeof(arg), "@", "");
 		rank2 = StringToInt(arg);
 	}
 	else if(arg[0]) // Look for in-game player with argument for comparing with -> rank2
@@ -6043,7 +6043,7 @@ public Action Command_CPR(int client, int args)
 		{
 			if (IsValidClient(i) && !IsClientSourceTV(i))
 			{
-				GetClientName(i, szPlayerName, MAX_NAME_LENGTH);
+				GetClientName(i, szPlayerName, sizeof(szPlayerName));
 				StringToUpper(szPlayerName);
 				
 				if ((StrContains(szPlayerName, arg) != -1))

--- a/addons/sourcemod/scripting/surftimer/commands.sp
+++ b/addons/sourcemod/scripting/surftimer/commands.sp
@@ -6014,9 +6014,16 @@ public Action Command_CPR(int client, int args)
 	}
 	else return Plugin_Handled;
 
-	if (args == 1) // compare client argument (rank1) with record for current map
+	if (args == 1) 
 	{
-		db_selectCPR(client, rank1, g_szMapName, 1, 1);
+		if (g_fPersonalRecord[client] > 0.0) // compare client rank with argument supplied
+		{
+			db_selectCPR(client, g_MapRank[client], g_szMapName, rank1, 1);
+		}
+		else // compare client argument (rank1) with record for current map
+		{
+			db_selectCPR(client, rank1, g_szMapName, 1, 1);
+		}
 	}
 
 	// Get the second rank to compare -> rank2

--- a/addons/sourcemod/scripting/surftimer/commands.sp
+++ b/addons/sourcemod/scripting/surftimer/commands.sp
@@ -5963,7 +5963,7 @@ public Action Command_CPR(int client, int args)
 	{
 		if (g_fPersonalRecord[client] > 0.0)
 		{
-			db_selectCPR(client, g_MapRank[client], g_szMapName, 1);
+			db_selectCPR(client, g_MapRank[client], g_szMapName, 1, 1);
 		}
 		else
 		{
@@ -6016,7 +6016,7 @@ public Action Command_CPR(int client, int args)
 
 	if (args == 1) // compare client argument (rank1) with record for current map
 	{
-		db_selectCPR(client, rank1, g_szMapName, 1);
+		db_selectCPR(client, rank1, g_szMapName, 1, 1);
 	}
 
 	// Get the second rank to compare -> rank2
@@ -6062,13 +6062,13 @@ public Action Command_CPR(int client, int args)
 		// Use current map or client asked for a specific one
 		GetCmdArg(3, arg, sizeof(arg));
 		if (arg[0])
-			db_selectCPR(client, rank1, arg, rank2);
+			db_selectCPR(client, rank1, arg, rank2, 0);
 		else	
-			db_selectCPR(client, rank1, g_szMapName, rank2);
+			db_selectCPR(client, rank1, g_szMapName, rank2, 1);
 	}
 	else
 	{
-		db_selectCPR(client, rank1, g_szMapName, rank2);
+		db_selectCPR(client, rank1, g_szMapName, rank2, 1);
 	}
 	return Plugin_Handled;
 }

--- a/addons/sourcemod/scripting/surftimer/sql.sp
+++ b/addons/sourcemod/scripting/surftimer/sql.sp
@@ -10572,6 +10572,9 @@ public void SQL_SelectCPRTimeCallback(Handle owner, Handle hndl, const char[] er
 	int client = ReadPackCell(pack);
 	int rank1 = ReadPackCell(pack);
 	int rank2 = ReadPackCell(pack);
+	// stop warning messages for unused variables, thanks @Bara
+	if (rank1) {}
+	if (rank2) {}
 
 	if (SQL_HasResultSet(hndl) && SQL_FetchRow(hndl))
 	{
@@ -10631,6 +10634,10 @@ public void db_selectCPRTarget(any pack)
 	int rank2 = ReadPackCell(pack);
 	char firstTargetName[MAX_NAME_LENGTH];
 	ReadPackString(pack, firstTargetName, sizeof(firstTargetName));
+
+	// stop warning messages for unused variables, thanks @Bara
+	if (rank1) {}
+	if (rank2) {}
 
 	// Find CPR target rank SteamID
 	char szQuery[512];

--- a/addons/sourcemod/scripting/surftimer/sql.sp
+++ b/addons/sourcemod/scripting/surftimer/sql.sp
@@ -10518,8 +10518,9 @@ public void SQL_SetJoinMsgCallback(Handle owner, Handle hndl, const char[] error
  * @param rank				First rank targeted by the client
  * @param szMapName			Mapname for the queries
  * @param rank2				Second rank targeted by the client
+ * @param queryCase			Use 1 when using the current map name (does NOT contain LIKE in query)
  */
-public void db_selectCPR(int client, int rank, const char szMapName[128], int rank2)
+public void db_selectCPR(int client, int rank, const char szMapName[128], int rank2, int queryCase)
 {
 	/*
 	* Info on the DataPack used for the !cpr command
@@ -10543,7 +10544,17 @@ public void db_selectCPR(int client, int rank, const char szMapName[128], int ra
 
 	char szQuery[512];
 	// Query to get SteamID for first CPR target
-	Format(szQuery, sizeof(szQuery), "SELECT `steamid`, `name`, `mapname`, `runtimepro` FROM `ck_playertimes` WHERE `mapname` LIKE '%c%s%c' AND style = 0 ORDER BY `runtimepro` ASC LIMIT %i, 1", PERCENT, szMapName, PERCENT, rank-1);
+	switch(queryCase)
+	{
+		case 0:
+		{
+			Format(szQuery, sizeof(szQuery), "SELECT `steamid`, `name`, `mapname`, `runtimepro` FROM `ck_playertimes` WHERE `mapname` LIKE '%c%s%c' AND style = 0 ORDER BY `runtimepro` ASC LIMIT %i, 1", PERCENT, szMapName, PERCENT, rank-1);
+		}
+		case 1:
+		{
+			Format(szQuery, sizeof(szQuery), "SELECT `steamid`, `name`, `mapname`, `runtimepro` FROM `ck_playertimes` WHERE `mapname`='%s' AND style = 0 ORDER BY `runtimepro` ASC LIMIT %i, 1", szMapName, rank-1);
+		}
+	}
 
 	SQL_TQuery(g_hDb, SQL_SelectCPRTimeCallback, szQuery, pack, DBPrio_Low);
 }

--- a/addons/sourcemod/scripting/surftimer/sql.sp
+++ b/addons/sourcemod/scripting/surftimer/sql.sp
@@ -10698,6 +10698,9 @@ public void SQL_SelectCPRTargetCPsCallback(Handle owner, Handle hndl, const char
 		char firstTargetName[MAX_NAME_LENGTH];
 		ReadPackString(pack, firstTargetName, sizeof(firstTargetName));
 
+		// stop warning messages for unused variables, thanks @Bara
+		if (rank2) {}
+
 		Menu menu = CreateMenu(CPRMenuHandler);
 		char szTitle[256], szName[MAX_NAME_LENGTH];
 		GetClientName(client, szName, sizeof(szName));

--- a/addons/sourcemod/scripting/surftimer/sql.sp
+++ b/addons/sourcemod/scripting/surftimer/sql.sp
@@ -10511,51 +10511,6 @@ public void SQL_SetJoinMsgCallback(Handle owner, Handle hndl, const char[] error
 		CPrintToChat(client, "%t", "SQLTwo6", g_szChatPrefix, g_szCustomJoinMsg[client]);
 }
 
-// public void db_precacheCustomSounds()
-// {
-// 	char szQuery[512];
-// 	Format(szQuery, sizeof(szQuery), "SELECT pbsound, topsound, wrsound FROM ck_vipadmins");
-// 	SQL_TQuery(g_hDb, SQL_PrecacheCustomSoundsCallback szQuery, 1, DBPrio_Low);
-// }
-
-// public void SQL_SetJoinMsgCallback(Handle owner, Handle hndl, const char[] error, any data)
-// {
-// 	if (hndl == null)
-// 	{
-// 		LogError("[surftimer] SQL Error (SQL_PrecacheCustomSoundsCallback): %s", error);
-// 		return;
-// 	}
-
-// 	if (SQL_HasResultSet(hndl))
-// 	{
-// 		char pbsound[256], topsound[256], wrsound[256];
-// 		while (SQL_FetchRow(hndl))
-// 		{
-// 			SQL_FetchString(hndl, 0, pbsound, sizeof(pbsound));
-// 			SQL_FetchString(hndl, 1, topsound, sizeof(topsound));
-// 			SQL_FetchString(hndl, 2, wrsound, sizeof(wrsound));
-
-// 			if (!StrEqual(pbsound, "none"))
-// 			{
-// 				AddFileToDownloadsTable(pbsound);
-// 				FakePrecacheSound(pbsound);
-// 			}
-
-// 			if (!StrEqual(topsound, "none"))
-// 			{
-// 				AddFileToDownloadsTable(topsound);
-// 				FakePrecacheSound(topsound);
-// 			}
-
-// 			if (!StrEqual(wrsound, "none"))
-// 			{
-// 				AddFileToDownloadsTable(wrsound);
-// 				FakePrecacheSound(wrsound);
-// 			}
-// 		}
-// 	}
-// }
-
 /*
  * CPR Command Info
  * 

--- a/addons/sourcemod/translations/surftimer.phrases.txt
+++ b/addons/sourcemod/translations/surftimer.phrases.txt
@@ -856,6 +856,11 @@
 		"#format"	"{1:s}"
 		"en"		"{1} New stage start position saved"
 	}
+	"Commands90"
+	{
+		"#format"	"{1:s}"
+		"en"		"{1} You {darkred}do not{default} have a personal best yet, use:\n{1} !cpr {green}@<rank> @<rank> {blue}<mapname> {default}(mapname is optional)"
+	}
 	"BotInUse"
 	{
 		"#format"	"{1:s},{2:s}"
@@ -1982,4 +1987,5 @@
 		"#format"	"{1:s}"
 		"en"		"{1} {yellow}Already Max Rank!"
 	}
+	""
 }

--- a/addons/sourcemod/translations/surftimer.phrases.txt
+++ b/addons/sourcemod/translations/surftimer.phrases.txt
@@ -1987,5 +1987,4 @@
 		"#format"	"{1:s}"
 		"en"		"{1} {yellow}Already Max Rank!"
 	}
-	""
 }


### PR DESCRIPTION
With this PR players can now use `/cpr @<rank> @<rank> <mapname>` as well as `/cpr @<rank> <in-game Player name> <mapname>` where mapname is optional on all.

**Currently comparing 2 players with their names works only for the current map.**
Also comparing by name has not been altered from original (only looks for in-game players), only changed part is to include client that executed the command in the search otherwise client could not compare themselves with another player/rank by using their name.

~~Currently compiling this will throw warnings for unused variables:~~
![image](https://user-images.githubusercontent.com/74899888/222965565-97610e67-49a0-49cd-bde5-4ccc4419d85b.png)
~~The "fix" is to uncomment the `SetPackPosition` and `DataPackPos` functions and remove the unused variables, the reason I have not done that is cause we would have to hardcode positions for the DataPack.~~
Fixed [here](https://github.com/surftimer/SurfTimer/pull/558/commits/eabefef34d5d31a9c2e192eed63c6a3ede04b07d) and [here](https://github.com/surftimer/SurfTimer/pull/558/commits/41084dfbebbea073c6ffdc5ac01a26332eb7d058)



Current known issues:
1. ~~Running the command on a map like `surf_beginner` will show `surf_beginner_lin` (in my case) cause of `LIKE` in the query~~ Fixed [here](https://github.com/surftimer/SurfTimer/pull/558/commits/2415613162349a6464eb32f623922a0d09eab5e6)