### PR TITLE
Add surftimer_OnStageFinished forward

### DIFF
--- a/addons/sourcemod/scripting/include/surftimer.inc
+++ b/addons/sourcemod/scripting/include/surftimer.inc
@@ -241,6 +241,19 @@ forward void surftimer_OnNewRecord(int client, int style, char[] time, char[] ti
 forward void surftimer_OnNewWRCP(int client, int style, char[] time, char[] timeDif, int stage, float fRunTime);
 
 /**
+ * Called when a client sets a new WRCP
+ *
+ * @param client			The client's ID.
+ * @param style				Style index.
+ * @param time				Time set by the player.
+ * @param timeDif			Time difference with the former record.
+ * @param stage			  	The id of the stage of the WRCP.
+ * @param fRunTime			Run time for the WRCP in float.
+ * @param fClientRunTime	Run time for the client of the current stage in float.
+ */
+forward void surftimer_OnStageFinished(int client, int style, char[] time, char[] timeDif, int stage, float fRunTime, float fClientRunTime);
+
+/**
  * Converts steamid2 (STEAM_X:Y:Z) to the accountid which will returned.
  */
 stock int SteamId2ToAccountId(const char[] steamid)
@@ -270,4 +283,5 @@ public __pl_surftimer_SetNTVOptional()
 	MarkNativeAsOptional("surftimer_GetServerRank");
 	MarkNativeAsOptional("surftimer_SafeTeleport");
 	MarkNativeAsOptional("surftimer_OnNewRecord");
+	MarkNativeAsOptional("surftimer_OnStageFinished");
 }

--- a/addons/sourcemod/scripting/surftimer/api.sp
+++ b/addons/sourcemod/scripting/surftimer/api.sp
@@ -331,6 +331,7 @@ void Register_Forwards()
 	g_PracticeFinishForward = new GlobalForward("surftimer_OnPracticeFinished", ET_Event, Param_Cell, Param_Float, Param_String);
 	g_NewRecordForward = new GlobalForward("surftimer_OnNewRecord", ET_Event, Param_Cell, Param_Cell, Param_String, Param_String, Param_Cell);
 	g_NewWRCPForward = new GlobalForward("surftimer_OnNewWRCP", ET_Event, Param_Cell, Param_Cell, Param_String, Param_String, Param_Cell, Param_Float);
+	g_StageFinishForward = new GlobalForward("surftimer_OnStageFinished", ET_Event, Param_Cell, Param_Cell, Param_String, Param_String, Param_Cell, Param_Float, Param_Float);
 }
 
 /**
@@ -488,4 +489,32 @@ void SendNewWRCPForward(int client, int stage, const char[] szRecordDiff, float 
 	Call_Finish();
 }
 
+/**
+ * Sends a new stage forward on surftimer_OnStageFinished.
+ * 
+ * @param client           Index of the client.
+ * @param stage            ID of the stage.
+ * @param szRecordDiff     String containing the formatted difference with the previous record.
+ * @param fRunTime		   Float value for the record time
+ */
+void SendStageFinishedForward(int client, int stage, const char[] szRecordDiff, float fRunTime)
+{
+	char szStageTime[64];
+	FormatTimeFloat(client, g_fCurrentWrcpRunTime[client], 3, szStageTime, sizeof(szStageTime));
+	
+	/* Start stage finished function call */
+	Call_StartForward(g_StageFinishForward);
+
+	/* Push parameters one at a time */
+	Call_PushCell(client);
+	Call_PushCell(g_iCurrentStyle[client]);
+	Call_PushString(szStageTime);
+	Call_PushString(szRecordDiff);
+	Call_PushCell(stage);
+	Call_PushFloat(fRunTime);
+	Call_PushFloat(g_fCurrentWrcpRunTime[client]);
+
+	/* Finish the call, get the result */
+	Call_Finish();
+}
 /*======  End of Forwards  ======*/

--- a/addons/sourcemod/scripting/surftimer/globals.sp
+++ b/addons/sourcemod/scripting/surftimer/globals.sp
@@ -699,6 +699,7 @@ GlobalForward g_BonusFinishForward;
 GlobalForward g_PracticeFinishForward;
 GlobalForward g_NewRecordForward;
 GlobalForward g_NewWRCPForward;
+GlobalForward g_StageFinishForward;
 
 /*----------  SQL Variables  ----------*/
 

--- a/addons/sourcemod/scripting/surftimer/surfzones.sp
+++ b/addons/sourcemod/scripting/surftimer/surfzones.sp
@@ -503,7 +503,7 @@ public void StartTouch(int client, int action[3])
 			else if (g_iCurrentStyle[client] != 0)
 				f_srDiff = (g_fStyleStageRecord[g_iCurrentStyle[client]][g_Stage[0][client]] - g_fCurrentWrcpRunTime[client]);
 			
-			FormatTimeFloat(client, f_srDiff, 3, sz_srRawDiff, 128);
+			FormatTimeFloat(client, f_srDiff, 3, sz_srRawDiff, sizeof(sz_srRawDiff));
 
 			if (f_srDiff > 0)
 				Format(sz_srRawDiff, sizeof sz_srRawDiff, "-%s", sz_srRawDiff);

--- a/addons/sourcemod/scripting/surftimer/surfzones.sp
+++ b/addons/sourcemod/scripting/surftimer/surfzones.sp
@@ -494,6 +494,27 @@ public void StartTouch(int client, int action[3])
 
 			// Prevents the Stage(X) replay from starting before the Stage(X) start zone
 			g_iStageStartTouchTick[client] = g_iRecordedTicks[client]; //Add pre
+			
+			char sz_srRawDiff[128];
+			float f_srDiff;
+
+			if (g_iCurrentStyle[client] == 0)
+				f_srDiff = (g_fStageRecord[g_Stage[0][client]] - g_fCurrentWrcpRunTime[client]);
+			else if (g_iCurrentStyle[client] != 0)
+				f_srDiff = (g_fStyleStageRecord[g_iCurrentStyle[client]][g_Stage[0][client]] - g_fCurrentWrcpRunTime[client]);
+			
+			FormatTimeFloat(client, f_srDiff, 3, sz_srRawDiff, 128);
+
+			if (f_srDiff > 0)
+				Format(sz_srRawDiff, sizeof sz_srRawDiff, "-%s", sz_srRawDiff);
+			else
+				Format(sz_srRawDiff, sizeof sz_srRawDiff, "+%s", sz_srRawDiff);
+			
+			if (g_iCurrentStyle[client] == 0)
+				SendStageFinishedForward(client, g_Stage[0][client], sz_srRawDiff, g_fStageRecord[g_Stage[0][client]]);
+			else if (g_iCurrentStyle[client] != 0)
+				SendStageFinishedForward(client, g_Stage[0][client], sz_srRawDiff, g_fStyleStageRecord[g_iCurrentStyle[client]][g_Stage[0][client]]);
+
 			// stop bot wrcp timer
 			if (client == g_WrcpBot)
 			{


### PR DESCRIPTION
We currently only have a forward whenever a new `WRCP` is made but not for regular Stage finishes.

This PR is to try and follow the already existing structure for forwards like `OnMapFinished` and `OnBonusFinished`.
