### PR TITLE
Fix /hide and a few other player SDKHooks

### DIFF
--- a/addons/sourcemod/scripting/SurfTimer.sp
+++ b/addons/sourcemod/scripting/SurfTimer.sp
@@ -416,6 +416,16 @@ public void OnClientPutInServer(int client)
 		return;
 	}
 
+	// SDKHooks
+	if (g_bClientHooksCalled[client] == false)
+	{
+		SDKHook(client, SDKHook_SetTransmit, Hook_SetTransmit);
+		SDKHook(client, SDKHook_PostThinkPost, Hook_PostThinkPost);
+		SDKHook(client, SDKHook_OnTakeDamage, Hook_OnTakeDamage);
+		SDKHook(client, SDKHook_PreThink, OnPlayerThink);
+		g_bClientHooksCalled[client] = true;
+	}
+
 	// Get SteamID
 	if (!GetClientAuthId(client, AuthId_Steam2, g_szSteamID[client], sizeof(g_szSteamID[]), true))
 	{
@@ -434,12 +444,6 @@ public void OnClientPutInServer(int client)
 	// Defaults
 	SetClientDefaults(client);
 	Command_Restart(client, 1);
-
-	// SDKHooks
-	SDKHook(client, SDKHook_SetTransmit, Hook_SetTransmit);
-	SDKHook(client, SDKHook_PostThinkPost, Hook_PostThinkPost);
-	SDKHook(client, SDKHook_OnTakeDamage, Hook_OnTakeDamage);
-	SDKHook(client, SDKHook_PreThink, OnPlayerThink);
 
 	if (!IsFakeClient(client))
 	{

--- a/addons/sourcemod/scripting/surftimer/globals.sp
+++ b/addons/sourcemod/scripting/surftimer/globals.sp
@@ -1168,6 +1168,9 @@ char g_BlockedChatText[256][256];
 // Last time an overlay was displayed
 float g_fLastOverlay[MAXPLAYERS + 1];
 
+// Track player SDKHooks
+bool g_bClientHooksCalled[MAXPLAYERS + 1] = { false };
+
 /*----------  Player location restoring  ----------*/
 
 // Clients location was restored this run

--- a/addons/sourcemod/scripting/surftimer/misc.sp
+++ b/addons/sourcemod/scripting/surftimer/misc.sp
@@ -1197,6 +1197,8 @@ public bool Base_TraceFilter(int entity, int contentsMask, any data)
 
 public void SetClientDefaults(int client)
 {
+	g_bClientHooksCalled[client] = false;
+	
 	g_fLastCommandBack[client] = GetGameTime();
 	g_ClientSelectedZone[client] = -1;
 	g_Editing[client] = 0;


### PR DESCRIPTION
Currently facing a weird issue with the dev branch - seems like /hide no longer works as expected. I did some digging and it seems like calling SDKHooks after the SteamID validation stuff in `OnPlayerPutInServer` is causing the issue. 

Not entirely sure exactly why that happens, but I moved the SDKHook calls above the SteamID validation code in the function. I've also added a new bool to try and ensure that the SDKHook functions get called only once, as a safeguard. (Not sure if this is truly required, but if it isn't, do let me know and I'll remove it)

Tested working on GFL and on the NA SurfTimer test server