### PR TITLE
[FIX] BeamBox_OnPlayerRunCmd

### DIFF
--- a/addons/sourcemod/scripting/surftimer/hooks.sp
+++ b/addons/sourcemod/scripting/surftimer/hooks.sp
@@ -1106,8 +1106,8 @@ public Action OnPlayerRunCmd(int client, int &buttons, int &impulse, float vel[3
 
 		g_fLastSpeed[client] = speed;
 		g_LastButton[client] = buttons;
-
-		BeamBox_OnPlayerRunCmd(client);
+		if (!IsFakeClient(client))
+			BeamBox_OnPlayerRunCmd(client);
 	}
 
 	// Strafe Sync taken from shavit's bhop timer

--- a/addons/sourcemod/scripting/surftimer/surfzones.sp
+++ b/addons/sourcemod/scripting/surftimer/surfzones.sp
@@ -952,6 +952,9 @@ public void getZoneDisplayColor(int type, int zColor[4], int zGrp)
 
 public void BeamBox_OnPlayerRunCmd(int client)
 {
+	if (client == 0 || client == g_WrcpBot || client == g_BonusBot || client == g_RecordBot)
+  		return;
+
 	if (g_Editing[client] == 1 || g_Editing[client] == 3 || g_Editing[client] == 10 || g_Editing[client] == 11)
 	{
 		float pos[3], ang[3];

--- a/addons/sourcemod/scripting/surftimer/surfzones.sp
+++ b/addons/sourcemod/scripting/surftimer/surfzones.sp
@@ -952,9 +952,6 @@ public void getZoneDisplayColor(int type, int zColor[4], int zGrp)
 
 public void BeamBox_OnPlayerRunCmd(int client)
 {
-	if (client == 0 || client == g_WrcpBot || client == g_BonusBot || client == g_RecordBot)
-  		return;
-
 	if (g_Editing[client] == 1 || g_Editing[client] == 3 || g_Editing[client] == 10 || g_Editing[client] == 11)
 	{
 		float pos[3], ang[3];


### PR DESCRIPTION
**_Not thoroughly tested._** (new runs are recorded, saved and replayed as expected)
Not really sure why we are sending zones drawing data to bots.

Fixes the error from #565. 
