### PR TITLE
On client put in server fix

### DIFF
--- a/addons/sourcemod/scripting/SurfTimer.sp
+++ b/addons/sourcemod/scripting/SurfTimer.sp
@@ -466,6 +466,7 @@ public void OnClientPutInServer(int client)
 		if (!GetClientAuthId(client, AuthId_Steam2, g_szSteamID[client], sizeof(g_szSteamID[]), true))
 		{
 			RequestFrame(OnClientPutInServer, client);
+			g_bLoadingSettings[client] = true;
 			return;
 		}
 
@@ -475,6 +476,7 @@ public void OnClientPutInServer(int client)
 		if (g_szSteamID[client][6] == 'I' && g_szSteamID[client][7] == 'D')
 		{
 			RequestFrame(OnClientPutInServer, client);
+			g_bLoadingSettings[client] = true;
 			return;
 		}
 		g_MVPStars[client] = 0;


### PR DESCRIPTION
If steamID was not initialized we would return from this function and therefore necessary bools and settings would not be set leading to some issues