### PR TITLE
[Addition] On Timer Start Forwards

### DIFF
--- a/addons/sourcemod/scripting/include/surftimer.inc
+++ b/addons/sourcemod/scripting/include/surftimer.inc
@@ -193,7 +193,7 @@ native bool surftimer_SafeTeleport(int client, float fDestination[3], float fAng
 forward void surftimer_OnClientTimerStart(int client, int style);
 
 /**
- * Called when a client map timer starts
+ * Called when a client WRCP timer starts
  *
  * @param client           Index of the client.
  * @param style			   Style the client is currently in
@@ -202,7 +202,7 @@ forward void surftimer_OnClientTimerStart(int client, int style);
 forward void surftimer_OnClientWRCPTimerStart(int client, int style, int stage);
 
 /**
- * Called when a client map timer starts
+ * Called when a client Bonus timer starts
  *
  * @param client           Index of the client.
  * @param style			   Style the client is currently in

--- a/addons/sourcemod/scripting/include/surftimer.inc
+++ b/addons/sourcemod/scripting/include/surftimer.inc
@@ -185,6 +185,32 @@ native bool surftimer_SafeTeleport(int client, float fDestination[3], float fAng
 /*  FORWARDS  */
 
 /**
+ * Called when a client map timer starts
+ *
+ * @param client           Index of the client.
+ * @param style			   Style the client is currently in
+ */
+forward void surftimer_OnClientTimerStart(int client, int style);
+
+/**
+ * Called when a client map timer starts
+ *
+ * @param client           Index of the client.
+ * @param style			   Style the client is currently in
+ * @param stage 		   Stage number the client is currently running
+ */
+forward void surftimer_OnClientWRCPTimerStart(int client, int style, int stage);
+
+/**
+ * Called when a client map timer starts
+ *
+ * @param client           Index of the client.
+ * @param style			   Style the client is currently in
+ * @param bonus 		   Bonus number the client is currently running
+ */
+forward void surftimer_OnClientBonusTimerStart(int client, int style, int bonus);
+
+/**
  * Called when a client finishes a map.
  *
  * @param client			The client's ID.

--- a/addons/sourcemod/scripting/include/surftimer.inc
+++ b/addons/sourcemod/scripting/include/surftimer.inc
@@ -188,7 +188,7 @@ native bool surftimer_SafeTeleport(int client, float fDestination[3], float fAng
  * Called when a client map timer starts
  *
  * @param client           Index of the client.
- * @param style			   Style the client is currently in
+ * @param style			   Style the client is currently in.
  */
 forward void surftimer_OnClientTimerStart(int client, int style);
 
@@ -196,8 +196,8 @@ forward void surftimer_OnClientTimerStart(int client, int style);
  * Called when a client WRCP timer starts
  *
  * @param client           Index of the client.
- * @param style			   Style the client is currently in
- * @param stage 		   Stage number the client is currently running
+ * @param style			   Style the client is currently in.
+ * @param stage 		   Stage number the client is currently running.
  */
 forward void surftimer_OnClientWRCPTimerStart(int client, int style, int stage);
 
@@ -205,10 +205,19 @@ forward void surftimer_OnClientWRCPTimerStart(int client, int style, int stage);
  * Called when a client Bonus timer starts
  *
  * @param client           Index of the client.
- * @param style			   Style the client is currently in
- * @param bonus 		   Bonus number the client is currently running
+ * @param style			   Style the client is currently in.
+ * @param bonus 		   Bonus number the client is currently running.
  */
 forward void surftimer_OnClientBonusTimerStart(int client, int style, int bonus);
+
+/**
+ * Called when a client enters Practice mode
+ *
+ * @param client           Index of the client.
+ * @param style			   Style the client is currently in.
+ * @param locNum 		   Number of the saveloc the client teleported to.
+ */
+forward void surftimer_OnClientPracTimerStart(int client, int style, int locNum);
 
 /**
  * Called when a client finishes a map.

--- a/addons/sourcemod/scripting/surftimer/api.sp
+++ b/addons/sourcemod/scripting/surftimer/api.sp
@@ -337,6 +337,7 @@ void Register_Forwards()
 	g_OnClientTimerStart = new GlobalForward("surftimer_OnClientTimerStart", ET_Event, Param_Cell, Param_Cell);
 	g_OnClientWRCPTimerStart = new GlobalForward("surftimer_OnClientWRCPTimerStart", ET_Event, Param_Cell, Param_Cell, Param_Cell);
 	g_OnClientBonusTimerStart = new GlobalForward("surftimer_OnClientBonusTimerStart", ET_Event, Param_Cell, Param_Cell, Param_Cell);
+	g_OnClientPracTimerStart = new GlobalForward("surftimer_OnClientPracTimerStart", ET_Event, Param_Cell, Param_Cell, Param_Cell);
 }
 
 /**
@@ -362,8 +363,8 @@ void OnClientTimerStartForward(int client)
  * Sends a forward on surftimer_OnClientWRCPTimerStart when a client WRCP timer starts (no bonuses or main map).
  * 
  * @param client           Index of the client.
- * @param style			   Style the client is currently in
- * @param stage 		   Stage number the client is currently running
+ * @param style			   Style the client is currently in.
+ * @param stage 		   Stage number the client is currently running.
  */
 void OnClientWRCPTimerStartForward(int client)
 {
@@ -386,8 +387,8 @@ void OnClientWRCPTimerStartForward(int client)
  * Sends a forward on surftimer_OnClientBonusTimerStartForward when a client Bonus timer starts (no WRCP or main map).
  * 
  * @param client           Index of the client.
- * @param style			   Style the client is currently in
- * @param bonus 		   Bonus number the client is currently running
+ * @param style			   Style the client is currently in.
+ * @param bonus 		   Bonus number the client is currently running.
  */
 void OnClientBonusTimerStartForward(int client)
 {
@@ -398,6 +399,27 @@ void OnClientBonusTimerStartForward(int client)
 	Call_PushCell(client);
 	Call_PushCell(g_iCurrentStyle[client]);
 	Call_PushCell(g_iInBonus[client]);
+
+	/* Finish the call, get the result */
+	Call_Finish();
+}
+
+/**
+ * Sends a forward on surftimer_OnClientPracTimerStart when a client enters practice mode.
+ * 
+ * @param client           Index of the client.
+ * @param style			   Style the client is currently in.
+ * @param locNum 		   Number of the saveloc the client teleported to.
+ */
+void OnClientPracTimerStartForward(int client)
+{
+	/* Start New record function call */
+	Call_StartForward(g_OnClientPracTimerStart);
+
+	/* Push parameters one at a time */
+	Call_PushCell(client);
+	Call_PushCell(g_iCurrentStyle[client]);
+	Call_PushCell(g_iLastSaveLocIdClient[client]);
 
 	/* Finish the call, get the result */
 	Call_Finish();

--- a/addons/sourcemod/scripting/surftimer/api.sp
+++ b/addons/sourcemod/scripting/surftimer/api.sp
@@ -332,6 +332,75 @@ void Register_Forwards()
 	g_NewRecordForward = new GlobalForward("surftimer_OnNewRecord", ET_Event, Param_Cell, Param_Cell, Param_String, Param_String, Param_Cell);
 	g_NewWRCPForward = new GlobalForward("surftimer_OnNewWRCP", ET_Event, Param_Cell, Param_Cell, Param_String, Param_String, Param_Cell, Param_Float);
 	g_StageFinishForward = new GlobalForward("surftimer_OnStageFinished", ET_Event, Param_Cell, Param_Cell, Param_String, Param_String, Param_Cell, Param_Float, Param_Float);
+
+	/* More Forwards */
+	g_OnClientTimerStart = new GlobalForward("surftimer_OnClientTimerStart", ET_Event, Param_Cell, Param_Cell);
+	g_OnClientWRCPTimerStart = new GlobalForward("surftimer_OnClientWRCPTimerStart", ET_Event, Param_Cell, Param_Cell, Param_Cell);
+	g_OnClientBonusTimerStart = new GlobalForward("surftimer_OnClientBonusTimerStart", ET_Event, Param_Cell, Param_Cell, Param_Cell);
+}
+
+/**
+ * Sends a forward on surftimer_OnClientTimerStart when a client timer starts (no WRCP or bonuses).
+ * 
+ * @param client           Index of the client.
+ * @param style			   Style the client is currently in
+ */
+void OnClientTimerStartForward(int client)
+{
+	/* Start New record function call */
+	Call_StartForward(g_OnClientTimerStart);
+
+	/* Push parameters one at a time */
+	Call_PushCell(client);
+	Call_PushCell(g_iCurrentStyle[client]);
+
+	/* Finish the call, get the result */
+	Call_Finish();
+}
+
+/**
+ * Sends a forward on surftimer_OnClientWRCPTimerStart when a client WRCP timer starts (no bonuses or main map).
+ * 
+ * @param client           Index of the client.
+ * @param style			   Style the client is currently in
+ * @param stage 		   Stage number the client is currently running
+ */
+void OnClientWRCPTimerStartForward(int client)
+{
+	// int iStage = 9999;
+	int iStage = g_Stage[0][client];
+
+	/* Start New record function call */
+	Call_StartForward(g_OnClientWRCPTimerStart);
+
+	/* Push parameters one at a time */
+	Call_PushCell(client);
+	Call_PushCell(g_iCurrentStyle[client]);
+	Call_PushCell(iStage);
+
+	/* Finish the call, get the result */
+	Call_Finish();
+}
+
+/**
+ * Sends a forward on surftimer_OnClientBonusTimerStartForward when a client Bonus timer starts (no WRCP or main map).
+ * 
+ * @param client           Index of the client.
+ * @param style			   Style the client is currently in
+ * @param bonus 		   Bonus number the client is currently running
+ */
+void OnClientBonusTimerStartForward(int client)
+{
+	/* Start New record function call */
+	Call_StartForward(g_OnClientBonusTimerStart);
+
+	/* Push parameters one at a time */
+	Call_PushCell(client);
+	Call_PushCell(g_iCurrentStyle[client]);
+	Call_PushCell(g_iInBonus[client]);
+
+	/* Finish the call, get the result */
+	Call_Finish();
 }
 
 /**

--- a/addons/sourcemod/scripting/surftimer/buttonpress.sp
+++ b/addons/sourcemod/scripting/surftimer/buttonpress.sp
@@ -96,6 +96,8 @@ public void CL_OnStartTimerPress(int client)
 
 				SetPrestrafe(client, 0, g_iCurrentStyle[client], true, false, false );
 				SetPrestrafe(client, 1, g_iCurrentStyle[client], true, false, false );
+
+				OnClientTimerStartForward(client);
 			}
 			else // bonus
 			{
@@ -106,6 +108,8 @@ public void CL_OnStartTimerPress(int client)
 				iPersonalPrestrafeRecord = g_iPersonalRecordPreStrafeBonus[client][g_PreSpeedMode[client]][g_iClientInZone[client][2]][g_iCurrentStyle[client]];
 
 				SetPrestrafe(client, g_iClientInZone[client][2], g_iCurrentStyle[client], false, true, false);
+				
+				OnClientBonusTimerStartForward(client);
 			}
 		}
 
@@ -159,10 +163,13 @@ public void CL_OnStartTimerPress(int client)
 			Format(szSpeed, sizeof(szSpeed), "%i", prestrafe);
 
 			if (g_iClientInZone[client][2] == 0)
+			{
 				Format(preMessage, sizeof(preMessage), "%t", "StartPrestrafe", g_szChatPrefix, szSpeed, szPersonalDifference, szRecordDifference);
+			}
 			else
+			{
 				Format(preMessage, sizeof(preMessage), "%t", "BonusPrestrafe", g_szChatPrefix, g_iClientInZone[client][2], szSpeed, szPersonalDifference, szRecordDifference);
-
+			}
 			if (g_iPrespeedText[client])
 				CPrintToChat(client, preMessage);
 		
@@ -189,6 +196,7 @@ public void CL_OnStartTimerPress(int client)
 
 	// Play Start Sound
 	PlayButtonSound(client);
+	
 
 	// Add pre
 	// // Start recording for record bot
@@ -916,6 +924,7 @@ public void CL_OnStartWrcpTimerPress(int client)
 					CPrintToChat(i, preMessage);
 			}
 		}
+		OnClientWRCPTimerStartForward(client);
 	}
 }
 
@@ -1067,6 +1076,7 @@ public void CL_OnStartPracSrcpTimerPress(int client)
 				g_iPracSrcpStage[client] = g_Stage[g_iClientInZone[client][2]][client];
 			}
 		}
+		// OnClientTimerStartForward(client);
 	}
 }
 

--- a/addons/sourcemod/scripting/surftimer/buttonpress.sp
+++ b/addons/sourcemod/scripting/surftimer/buttonpress.sp
@@ -96,8 +96,6 @@ public void CL_OnStartTimerPress(int client)
 
 				SetPrestrafe(client, 0, g_iCurrentStyle[client], true, false, false );
 				SetPrestrafe(client, 1, g_iCurrentStyle[client], true, false, false );
-
-				OnClientTimerStartForward(client);
 			}
 			else // bonus
 			{
@@ -108,8 +106,6 @@ public void CL_OnStartTimerPress(int client)
 				iPersonalPrestrafeRecord = g_iPersonalRecordPreStrafeBonus[client][g_PreSpeedMode[client]][g_iClientInZone[client][2]][g_iCurrentStyle[client]];
 
 				SetPrestrafe(client, g_iClientInZone[client][2], g_iCurrentStyle[client], false, true, false);
-				
-				OnClientBonusTimerStartForward(client);
 			}
 		}
 
@@ -165,10 +161,12 @@ public void CL_OnStartTimerPress(int client)
 			if (g_iClientInZone[client][2] == 0)
 			{
 				Format(preMessage, sizeof(preMessage), "%t", "StartPrestrafe", g_szChatPrefix, szSpeed, szPersonalDifference, szRecordDifference);
+				OnClientTimerStartForward(client);
 			}
 			else
 			{
 				Format(preMessage, sizeof(preMessage), "%t", "BonusPrestrafe", g_szChatPrefix, g_iClientInZone[client][2], szSpeed, szPersonalDifference, szRecordDifference);
+				OnClientBonusTimerStartForward(client);
 			}
 			if (g_iPrespeedText[client])
 				CPrintToChat(client, preMessage);
@@ -1076,7 +1074,6 @@ public void CL_OnStartPracSrcpTimerPress(int client)
 				g_iPracSrcpStage[client] = g_Stage[g_iClientInZone[client][2]][client];
 			}
 		}
-		// OnClientTimerStartForward(client);
 	}
 }
 

--- a/addons/sourcemod/scripting/surftimer/buttonpress.sp
+++ b/addons/sourcemod/scripting/surftimer/buttonpress.sp
@@ -194,30 +194,14 @@ public void CL_OnStartTimerPress(int client)
 
 	// Play Start Sound
 	PlayButtonSound(client);
-	
 
 	// Add pre
-	// // Start recording for record bot
-	// if ((!IsFakeClient(client) && GetConVarBool(g_hReplayBot)) || (!IsFakeClient(client) && GetConVarBool(g_hBonusBot)))
-	// {
-	// 	if (IsPlayerAlive(client))
-	// 	{
-	// 		StartRecording(client);
-	// 		if (g_bhasStages)
-	// 		{
-	// 			Stage_StartRecording(client);
-	// 		}
-	// 	}
-	// }
-
 	if (g_iRecordedTicks[client] == 0)
 		g_iStartPressTick[client] = g_iRecordedTicks[client];
 	else if (g_iRecordedTicks[client] >= (g_iTickrate * GetConVarInt(g_hReplayPre)))
 		g_iStartPressTick[client] = g_iRecordedTicks[client] - (g_iTickrate * GetConVarInt(g_hReplayPre));
 	else if (g_iRecordedTicks[client] >= g_iTickrate)
 		g_iStartPressTick[client] = g_iRecordedTicks[client] - g_iTickrate;
-			
-
 }
 
 // End Timer

--- a/addons/sourcemod/scripting/surftimer/globals.sp
+++ b/addons/sourcemod/scripting/surftimer/globals.sp
@@ -703,6 +703,7 @@ GlobalForward g_StageFinishForward;
 GlobalForward g_OnClientTimerStart;
 GlobalForward g_OnClientWRCPTimerStart;
 GlobalForward g_OnClientBonusTimerStart;
+GlobalForward g_OnClientPracTimerStart;
 
 /*----------  SQL Variables  ----------*/
 

--- a/addons/sourcemod/scripting/surftimer/globals.sp
+++ b/addons/sourcemod/scripting/surftimer/globals.sp
@@ -700,6 +700,9 @@ GlobalForward g_PracticeFinishForward;
 GlobalForward g_NewRecordForward;
 GlobalForward g_NewWRCPForward;
 GlobalForward g_StageFinishForward;
+GlobalForward g_OnClientTimerStart;
+GlobalForward g_OnClientWRCPTimerStart;
+GlobalForward g_OnClientBonusTimerStart;
 
 /*----------  SQL Variables  ----------*/
 

--- a/addons/sourcemod/scripting/surftimer/misc.sp
+++ b/addons/sourcemod/scripting/surftimer/misc.sp
@@ -4740,6 +4740,7 @@ public void TeleportToSaveloc(int client, int id)
 	DispatchKeyValue(client, "targetname", g_szSaveLocTargetname[id]);
 	SetEntPropVector(client, Prop_Data, "m_vecVelocity", view_as<float>( { 0.0, 0.0, 0.0 } ));
 	TeleportEntity(client, g_fSaveLocCoords[client][id], g_fSaveLocAngle[client][id], g_fSaveLocVel[client][id]);
+	OnClientPracTimerStartForward(client);
 }
 
 public void ReadDefaultTitlesWhitelist()


### PR DESCRIPTION
Adds 4 new forwards:

```
surftimer_OnClientTimerStart
```
- Triggered when client starts their timer (for main map runs)

```c
surftimer_OnClientWRCPTimerStart
```
- Triggered when client starts  their WRCP timer (stages only)

```
surftimer_OnClientBonusTimerStart
```
- Triggered when client starts their Bonus timer (bonuses only)

```
surftimer_OnClientPracTimerStart
```
- Triggered when client enters Practice Mode (all zones)