### PR TITLE
[Addition] Show Prestrafe speed in CSD

### DIFF
--- a/addons/sourcemod/scripting/SurfTimer.sp
+++ b/addons/sourcemod/scripting/SurfTimer.sp
@@ -581,6 +581,12 @@ public void OnClientDisconnect(int client)
 		return;
 	}
 
+	// Clear hudPrestrafe value
+	if (strlen(g_szPrespeedValue[client]) != 0)
+	{
+		FormatEx(g_szPrespeedValue[client], sizeof(g_szPrespeedValue), "");
+	}
+
 	// Database
 	if (IsValidClient(client) && !g_bRenaming)
 	{

--- a/addons/sourcemod/scripting/SurfTimer.sp
+++ b/addons/sourcemod/scripting/SurfTimer.sp
@@ -582,10 +582,7 @@ public void OnClientDisconnect(int client)
 	}
 
 	// Clear hudPrestrafe value
-	if (strlen(g_szPrespeedValue[client]) != 0)
-	{
-		FormatEx(g_szPrespeedValue[client], sizeof(g_szPrespeedValue), "");
-	}
+	g_szPrespeedValue[client][0] = '\0';
 
 	// Database
 	if (IsValidClient(client) && !g_bRenaming)

--- a/addons/sourcemod/scripting/surftimer/buttonpress.sp
+++ b/addons/sourcemod/scripting/surftimer/buttonpress.sp
@@ -895,7 +895,13 @@ public void CL_OnStartWrcpTimerPress(int client)
 			Format(preMessage, sizeof(preMessage), "%t", "StagePrestrafe", g_szChatPrefix, g_Stage[0][client], szSpeed, szPersonalDifference, szRecordDifference);
 
 			if (g_iPrespeedText[client])
+			{
 				CPrintToChat(client, preMessage);
+
+				// Add Prestrafe to global VAR
+				FormatEx(g_szPrespeedValue[client], sizeof(g_szPrespeedValue), "\n(%i)", prestrafe);
+				CreateTimer(2.0, hudPrestrafe, client);
+			}
 		
 			for (int i = 1; i <= MaxClients; i++) {
 				if (!IsClientInGame(i)) 

--- a/addons/sourcemod/scripting/surftimer/buttonpress.sp
+++ b/addons/sourcemod/scripting/surftimer/buttonpress.sp
@@ -900,7 +900,7 @@ public void CL_OnStartWrcpTimerPress(int client)
 
 				// Add Prestrafe to global VAR
 				FormatEx(g_szPrespeedValue[client], sizeof(g_szPrespeedValue), "\n(%i)", prestrafe);
-				CreateTimer(2.0, hudPrestrafe, client);
+				CreateTimer(2.0, hudPrestrafe, GetClientUserId(client));
 			}
 		
 			for (int i = 1; i <= MaxClients; i++) {

--- a/addons/sourcemod/scripting/surftimer/commands.sp
+++ b/addons/sourcemod/scripting/surftimer/commands.sp
@@ -3135,7 +3135,7 @@ void CenterSpeedDisplay(int client, bool menu = false)
 
 				SetHudTextParams(fCSD_PosX, fCSD_PosY, update_rate / g_fTickrate + 0.1, displayColor[0], displayColor[1], displayColor[2], 255, 0, 0.0, 0.0, 0.0);
 
-				Format(szSpeed, sizeof(szSpeed), "%i", RoundToNearest(g_fLastSpeed[client]));
+				Format(szSpeed, sizeof(szSpeed), "%i%s", RoundToNearest(g_fLastSpeed[client]), g_szPrespeedValue[client]);
 			}
 			// player not alive (check wether spec'ing a bot or another player)
 			else {
@@ -3199,7 +3199,7 @@ void CenterSpeedDisplay(int client, bool menu = false)
 
 							SetHudTextParams(fCSD_PosX, fCSD_PosY, update_rate / g_fTickrate + 0.1, displayColor[0], displayColor[1], displayColor[2], 255, 0, 0.0, 0.0, 0.0);
 
-							Format(szSpeed, sizeof(szSpeed), "%i", RoundToNearest(fSpeedHUD));
+							Format(szSpeed, sizeof(szSpeed), "%i%s", RoundToNearest(fSpeedHUD), g_szPrespeedValue[ObservedUser]);
 						}
 						// spec'ing player
 						else {
@@ -3213,7 +3213,7 @@ void CenterSpeedDisplay(int client, bool menu = false)
 
 							SetHudTextParams(fCSD_PosX, fCSD_PosY, update_rate / g_fTickrate + 0.1, displayColor[0], displayColor[1], displayColor[2], 255, 0, 0.0, 0.0, 0.0);
 
-							Format(szSpeed, sizeof(szSpeed), "%i", RoundToNearest(g_fLastSpeed[ObservedUser]));
+							Format(szSpeed, sizeof(szSpeed), "%i%s", RoundToNearest(g_fLastSpeed[ObservedUser]), g_szPrespeedValue[ObservedUser]);
 						}
 					}
 				}

--- a/addons/sourcemod/scripting/surftimer/globals.sp
+++ b/addons/sourcemod/scripting/surftimer/globals.sp
@@ -797,6 +797,7 @@ int g_iTeleSide[MAXPLAYERS + 1];
 
 // Prestrafe Message
 bool g_iPrespeedText[MAXPLAYERS + 1];
+char g_szPrespeedValue[MAXPLAYERS + 1][64];
 
 // Silent Spectate
 bool g_iSilentSpectate[MAXPLAYERS + 1];

--- a/addons/sourcemod/scripting/surftimer/timer.sp
+++ b/addons/sourcemod/scripting/surftimer/timer.sp
@@ -654,3 +654,14 @@ public Action DatabaseUpgrading(Handle timer)
 
 	return Plugin_Handled;
 }
+
+// Clear global prestrafe var for the client
+public Action hudPrestrafe(Handle timer, any client)
+{
+	if(IsValidClient(client) && IsClientInGame(client))
+	{
+		FormatEx(g_szPrespeedValue[client], sizeof(g_szPrespeedValue), "");
+	}
+
+	return Plugin_Handled;
+}

--- a/addons/sourcemod/scripting/surftimer/timer.sp
+++ b/addons/sourcemod/scripting/surftimer/timer.sp
@@ -656,8 +656,10 @@ public Action DatabaseUpgrading(Handle timer)
 }
 
 // Clear global prestrafe var for the client
-public Action hudPrestrafe(Handle timer, any client)
+public Action hudPrestrafe(Handle timer, any userid)
 {
+	int client = GetClientOfUserId(userid);
+	
 	if(IsValidClient(client) && IsClientInGame(client))
 	{
 		g_szPrespeedValue[client][0] = '\0';

--- a/addons/sourcemod/scripting/surftimer/timer.sp
+++ b/addons/sourcemod/scripting/surftimer/timer.sp
@@ -660,7 +660,7 @@ public Action hudPrestrafe(Handle timer, any client)
 {
 	if(IsValidClient(client) && IsClientInGame(client))
 	{
-		FormatEx(g_szPrespeedValue[client], sizeof(g_szPrespeedValue), "");
+		g_szPrespeedValue[client][0] = '\0';
 	}
 
 	return Plugin_Handled;


### PR DESCRIPTION
As per #592 .
Disappears after `2` seconds, works only when leaving **Map** or **Bonus** start zones 


![image](https://github.com/surftimer/SurfTimer/assets/74899888/80cdd557-aa52-4aac-a749-c336d661c99d)
