### PR TITLE
Make info panel text non reliable to increase update speed on high ping scenarios

### DIFF
--- a/addons/sourcemod/scripting/surftimer/misc.sp
+++ b/addons/sourcemod/scripting/surftimer/misc.sp
@@ -4905,7 +4905,7 @@ void PrintCSGOHUDText(int client, const char[] format, any ...)
 	VFormat(buff, sizeof(buff), format, 3);
 	Format(buff, sizeof(buff), "</font>%s<script>", buff);
 
-	Protobuf pb = view_as<Protobuf>(StartMessageOne("TextMsg", client, USERMSG_RELIABLE | USERMSG_BLOCKHOOKS));
+	Protobuf pb = view_as<Protobuf>(StartMessageOne("TextMsg", client, USERMSG_BLOCKHOOKS));
 	pb.SetInt("msg_dst", 4);
 	pb.AddString("params", "#SFUI_ContractKillStart");
 	pb.AddString("params", buff);


### PR DESCRIPTION
Previously the hint text panel update speed depends on the client ping, this is because the message is sent in a reliable channel. This means it will update really slowly if the client latency is significant. Besides, for something that updates as often as the info panel, that is not necessary. This change will finally make the info panel usable on high ping situations.

GOKZ has this feature since [some time ago](https://github.com/KZGlobalTeam/gokz/pull/450), I just figured it would also be useful here. 
I have seen some feedback in KZ saying the update speed is now "too fast" (because they are used to have a bit of latency that slows the update speed down, and KZ still has an option to slow down the update speed anyway), but for 64 tick gameplay I would assume it's not as much of a big deal.