### PR TITLE
[FIX] Checkpoints ArrayList 

### DIFF
--- a/addons/sourcemod/scripting/surftimer/surfzones.sp
+++ b/addons/sourcemod/scripting/surftimer/surfzones.sp
@@ -406,11 +406,12 @@ public void StartTouch(int client, int action[3])
 				ApplySpeedCapXY(client, g_mapZones[g_iClientInZone[client][3]].PreSpeed);
 			}
 
-			// StopRecording(client); //Add pre
 			StartRecording(client); //Add pre
 			/* Reset List newrecord-cp-list*/
-			if(g_aCheckpointsDifference[client] != null)
+			if(g_aCheckpointsDifference[client] != null && !g_bNewReplay[client])
+			{
 				g_aCheckpointsDifference[client].Clear();
+			}
 
 			if (g_bhasStages)
 			{
@@ -733,6 +734,11 @@ public void EndTouch(int client, int action[3])
 				if (!g_bNoClip[client])
 					g_bInStartZone[client] = false;
 
+				/* Reset List newrecord-cp-list*/
+				if(g_aCheckpointsDifference[client] != null && !g_bNewReplay[client])
+				{
+					g_aCheckpointsDifference[client].Clear();
+				}
 				g_bValidRun[client] = false;
 			}
 		}


### PR DESCRIPTION
I believe that if a player beats the rec and immediately `/r` it will clear the **_ArrayList_** and forward will send empty list causing the behavior from the screenshot below.

Solution is to check if a new replay is being saved and **NOT** clear the **_ArrayList_** if it's being saved, also added checking for this when leaving a **_StartZone_**

![image](https://github.com/surftimer/SurfTimer/assets/74899888/e5ac7e9a-5385-4b65-ae89-d50f1cb9bd16)
